### PR TITLE
Add support for pydantic's other union types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.3
+    rev: v0.15.9
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -26,7 +26,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.7.20
+    rev: 0.11.3
     hooks:
       - id: uv-lock
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ you must call `.model_rebuild(force=True)` on the model that uses the subclass
 union.
 
 ### Alternative union methods
+!!! warning "Caution"
+
+    `dynapydantic` does **NOT** test if your models have ambiguities in them.
+    This is up to **YOU**.
+
+    Non-discriminated unions should only be used when you can **PROVE** that all
+    possible subclasses will parse unambiguously. If there is ambiguity in the
+    models, you can get unexpected results. If plugins are used, it is highly
+    discouraged to use anything besides discriminated unions.
+
 While the default discriminated union is the recommended and most robust
 approach, it does require a field in the model to act as the discriminator. If
 the full list of union members is know to the author ahead of time and can be

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ union.
 
 While the default discriminated union is the recommended and most robust
 approach, it does require a field in the model to act as the discriminator. If
-the full list of union members is know to the author ahead of time and can be
+the full list of union members is known to the author ahead of time and can be
 proven to be unambiguous from a validation perspective, then the discriminator
 field can be omitted and a
 [`"smart"`](https://docs.pydantic.dev/latest/concepts/unions/#smart-mode) or

--- a/README.md
+++ b/README.md
@@ -58,9 +58,12 @@ Model(val=Base())
 Pydantic provides a solution for serialization via `serialize_as_any` (and
 its corresponding field annotation `SerializeAsAny`), but offers no native
 solution for the validation half. Currently, the canonical way of doing this
-is to annotate the field as a discriminated union of all subclasses. Often, a
-single field in the model is chosen as the "discriminator". This library,
-`dynapydantic`, automates this process.
+is to annotate the field as a union of all subclasses. Often, a single field
+in the model is chosen as the "discriminator" in a
+[discriminated union](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions).
+The discriminated pattern is the most robust way to do this, as it eliminates
+ambiguity between the union members. This library, `dynapydantic`, automates
+this process.
 
 Let's reframe the above problem with `dynapydantic`:
 ```python
@@ -93,7 +96,6 @@ Model(val=A(field=1, name='A'))
 >>> Model.model_validate(m.model_dump())
 Model(val=A(field=1, name='A')
 ```
-
 
 ## How it works
 
@@ -131,7 +133,7 @@ print(Model(field={"name": "B", "a": 5})) # field=B(name='B', a=5)
 
 The `union()` method produces a [discriminated union](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions)
 of all registered `pydantic.BaseModel` subclasses. It also accepts an
-`annotated=False` keyword argument to produce a plain `typing.Union` for use
+`plain=True` keyword argument to produce a plain `UnionType` for use
 in type annotations, but since this is a runtime-computed union, this will not
 work with static type checkers. This union is based on a discriminator field,
 which was configured by the `discriminator_field` argument to `TrackingGroup`.
@@ -210,3 +212,38 @@ were defined *prior* to defining the model that uses `dynapydantic.Polymorphic`
 (`Model` in the above example). If you declare additional subclasses afterwards,
 you must call `.model_rebuild(force=True)` on the model that uses the subclass
 union.
+
+### Alternative union methods
+While the default discriminated union is the recommended and most robust
+approach, it does require a field in the model to act as the discriminator. If
+the full list of union members is know to the author ahead of time and can be
+proven to be unambiguous from a validation perspective, then the discriminator
+field can be omitted and a
+[`"smart"`](https://docs.pydantic.dev/latest/concepts/unions/#smart-mode) or
+[`"left_to_right"`](https://docs.pydantic.dev/latest/concepts/unions/#left-to-right-mode)
+union may be used. `TrackingGroup` and `SubclassTrackingModel` support these
+modes as well via the `union_mode` argument:
+```python
+import typing as ty
+
+import dynapydantic
+import pydantic
+
+class Base(
+    dynapydantic.SubclassTrackingModel,
+    union_mode="smart",
+):
+    """dynapydantic.Polymorphic[Base] will be a "smart" A | B"""
+
+class A(Base):
+    a: int
+
+class B(Base):
+    b: int
+
+class Model(pydantic.BaseModel):
+    field: dynapydantic.Polymorphic[Base]
+
+print(Model(field={"b": 5}))
+# field=B(b=5)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,11 @@ plugins:
         python:
           options:
             docstring_style: numpy
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            show_signature_annotations: true
+            members_order: source
             extensions:
             - griffe_pydantic:
               schema: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
     "mkdocs-material>=9.6.15",
     "mkdocstrings[python]>=0.29.1",
     "pip>=25.1.1",
-    "pre-commit>=4.2.0",
+    "prek>=0.3.8",
     "pymdown-extensions>=10.16",
     "pyrefly>=0.44.1",
     "pytest>=8.4.1",
@@ -45,6 +45,7 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
+    "COM812", # trailing commas, handled by formatter
     "D400", # docstrings end in .
     "ANN002", # Annotations for *args
     "ANN003", # Annotations for *kwargs

--- a/src/dynapydantic/__init__.py
+++ b/src/dynapydantic/__init__.py
@@ -9,10 +9,12 @@ from .exceptions import (
 from .polymorphic import Polymorphic
 from .subclass_tracking_model import SubclassTrackingModel
 from .tracking_group import TrackingGroup
+from .union_mode import DiscriminatedConfig
 
 __all__ = [
     "AmbiguousDiscriminatorValueError",
     "ConfigurationError",
+    "DiscriminatedConfig",
     "Error",
     "Polymorphic",
     "RegistrationError",

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -10,6 +10,7 @@ from pydantic_core import core_schema
 
 from .exceptions import ConfigurationError
 from .tracking_group import TrackingGroup
+from .union_mode import DiscriminatedConfig
 
 
 def direct_children_of_base_in_mro(derived: type, base: type) -> list[type]:
@@ -29,24 +30,30 @@ def direct_children_of_base_in_mro(derived: type, base: type) -> list[type]:
     return [cls for cls in derived.__mro__ if cls is not base and base in cls.__bases__]
 
 
+_CLASS_KWARGS = set(TrackingGroup.model_fields) | set(DiscriminatedConfig.model_fields)
+
+
 class SubclassTrackingModel(pydantic.BaseModel):
     """Subclass-tracking BaseModel
 
-    This will inject a TrackingGroup into your class and automate the
-    registration of subclasses.
+    This will inject a [`TrackingGroup`][dynapydantic.TrackingGroup] into your
+    class and automate the registration of subclasses.
 
     Inheriting from this class will augment your class with the following
     members functions:
-    1. registered_subclasses() -> dict[str, type[cls]]:
+
+    1. `registered_subclasses() -> dict[str, type[cls]]`:
         This will return a mapping of discriminator value to the corresponding
-        sublcass. See TrackingGroup.models for details.
-    2. union() -> typing.GenericAlias:
+        subclass. See
+        [`TrackingGroup.models`][dynapydantic.TrackingGroup.models] for details.
+    2. `union() -> typing.Any`:
         This will return an (optionally) annotated subclass union. See
-        TrackingGroup.union() for details.
-    3. load_plugins() -> None:
+        [`TrackingGroup.union()`][dynapydantic.TrackingGroup.union] for details.
+    3. `load_plugins() -> None`:
         If plugin_entry_point was specified, then this method will load plugin
         packages to discover additional subclasses. See
-        TrackingGroup.load_plugins for more details.
+        [`TrackingGroup.load_plugins()`][dynapydantic.TrackingGroup.load_plugins]
+        for more details.
     """
 
     def __init_subclass__(cls, *args, **kwargs) -> None:
@@ -59,7 +66,7 @@ class SubclassTrackingModel(pydantic.BaseModel):
             **{
                 k: v
                 for k, v in kwargs.items()
-                if k not in TrackingGroup.model_fields and k not in sig.parameters
+                if k not in _CLASS_KWARGS and k not in sig.parameters
             },
         )
 
@@ -75,11 +82,7 @@ class SubclassTrackingModel(pydantic.BaseModel):
             # Intercept any kwargs that are intended for TrackingGroup
             super().__pydantic_init_subclass__(
                 *args,
-                **{
-                    k: v
-                    for k, v in kwargs.items()
-                    if k not in TrackingGroup.model_fields
-                },
+                **{k: v for k, v in kwargs.items() if k not in _CLASS_KWARGS},
             )
 
             if isinstance((tc := getattr(cls, "tracking_config", None)), TrackingGroup):
@@ -109,17 +112,24 @@ class SubclassTrackingModel(pydantic.BaseModel):
 
                 cls.load_plugins = staticmethod(_load_plugins)
 
-            def _union(*, annotated: bool = True) -> ty.GenericAlias:
+            def _union(
+                *,
+                plain: ty.Literal[True] | None = None,
+                annotated: bool | None = None,
+            ) -> ty.Any:  # noqa: ANN401
                 """Get the union of all tracked subclasses
 
                 Parameters
                 ----------
+                plain
+                    If set to `True`, a plain union of all members will be returned.
+                    Otherwise, the returned union will be annotated in accordance with
+                    the union mode.
                 annotated
-                    Whether this should be an annotated union for usage as a
-                    pydantic field annotation, or a plain typing.Union for a
-                    regular type annotation.
+                    Deprecated. Use `plain=True` when you would have used
+                    `annotated=False`.
                 """
-                return cls.__DYNAPYDANTIC__.union(annotated=annotated)
+                return cls.__DYNAPYDANTIC__.union(plain=plain, annotated=annotated)
 
             cls.union = staticmethod(_union)
 

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -10,7 +10,6 @@ from pydantic_core import core_schema
 
 from .exceptions import ConfigurationError
 from .tracking_group import TrackingGroup
-from .union_mode import DiscriminatedConfig
 
 
 def direct_children_of_base_in_mro(derived: type, base: type) -> list[type]:
@@ -28,9 +27,6 @@ def direct_children_of_base_in_mro(derived: type, base: type) -> list[type]:
     Classes in derived's MRO that are direct subclasses of base.
     """
     return [cls for cls in derived.__mro__ if cls is not base and base in cls.__bases__]
-
-
-_CLASS_KWARGS = set(TrackingGroup.model_fields) | set(DiscriminatedConfig.model_fields)
 
 
 class SubclassTrackingModel(pydantic.BaseModel):
@@ -66,7 +62,7 @@ class SubclassTrackingModel(pydantic.BaseModel):
             **{
                 k: v
                 for k, v in kwargs.items()
-                if k not in _CLASS_KWARGS and k not in sig.parameters
+                if k not in TrackingGroup.model_fields and k not in sig.parameters
             },
         )
 
@@ -82,7 +78,11 @@ class SubclassTrackingModel(pydantic.BaseModel):
             # Intercept any kwargs that are intended for TrackingGroup
             super().__pydantic_init_subclass__(
                 *args,
-                **{k: v for k, v in kwargs.items() if k not in _CLASS_KWARGS},
+                **{
+                    k: v
+                    for k, v in kwargs.items()
+                    if k not in TrackingGroup.model_fields
+                },
             )
 
             if isinstance((tc := getattr(cls, "tracking_config", None)), TrackingGroup):
@@ -114,9 +114,9 @@ class SubclassTrackingModel(pydantic.BaseModel):
 
             def _union(
                 *,
-                plain: ty.Literal[True] | None = None,
+                plain: bool | None = None,
                 annotated: bool | None = None,
-            ) -> ty.Any:  # noqa: ANN401
+            ) -> ty.Any:  # noqa: ANN401 - return type is runtime-determined
                 """Get the union of all tracked subclasses
 
                 Parameters
@@ -129,6 +129,7 @@ class SubclassTrackingModel(pydantic.BaseModel):
                     Deprecated. Use `plain=True` when you would have used
                     `annotated=False`.
                 """
+                # deprecation warning for annotated is in TrackingGroup
                 return cls.__DYNAPYDANTIC__.union(plain=plain, annotated=annotated)
 
             cls.union = staticmethod(_union)

--- a/src/dynapydantic/tracking_group.py
+++ b/src/dynapydantic/tracking_group.py
@@ -274,7 +274,7 @@ class TrackingGroup(pydantic.BaseModel):
     def union(
         self,
         *,
-        plain: ty.Literal[True] | None = None,
+        plain: bool | None = None,
         annotated: bool | None = None,
     ) -> ty.Any:  # noqa: ANN401
         """Return the union of all registered models

--- a/src/dynapydantic/tracking_group.py
+++ b/src/dynapydantic/tracking_group.py
@@ -1,13 +1,17 @@
 """Base class for dynamic pydantic models"""
 
 import contextlib
+import functools
+import operator
 import typing as ty
+import warnings
 
 import pydantic
 import pydantic.fields
 import pydantic_core
 
 from .exceptions import AmbiguousDiscriminatorValueError, RegistrationError
+from .union_mode import DiscriminatedConfig, UnionMode
 
 
 def _inject_discriminator_field(
@@ -46,8 +50,29 @@ class TrackingGroup(pydantic.BaseModel):
             "meaningfully named, as it will be used in error messages."
         ),
     )
-    discriminator_field: str = pydantic.Field(
-        description="Name of the discriminator field",
+    union_mode: UnionMode | None = pydantic.Field(
+        None,
+        description=(
+            "Union validation strategy. Pass a DiscriminatedConfig instance "
+            'or one of the plain strings "smart" or "left_to_right". You can '
+            "also just pass the fields for DiscriminatedConfig to this "
+            "model and they will be forwarded."
+        ),
+    )
+    discriminator_field: str | None = pydantic.Field(
+        None,
+        description=(
+            "Name of the discriminator field. NOTE: This field is "
+            "here as an alias for union_mode.discriminator_field. Passing "
+            "both a discriminator_field and a union_mode will result in an "
+            "error."
+        ),
+    )
+    discriminator_value_generator: ty.Callable[[type], str] | None = pydantic.Field(
+        None,
+        description=(
+            "A callable that produces default values for the discriminator field"
+        ),
     )
     plugin_entry_point: str | None = pydantic.Field(
         None,
@@ -60,16 +85,86 @@ class TrackingGroup(pydantic.BaseModel):
             "function, additional models may be declared in the function."
         ),
     )
-    discriminator_value_generator: ty.Callable[[type], str] | None = pydantic.Field(
-        None,
-        description=(
-            "A callable that produces default values for the discriminator field"
-        ),
-    )
     models: dict[str, type[pydantic.BaseModel]] = pydantic.Field(
         {},
         description="The tracked models",
     )
+
+    @pydantic.model_validator(mode="after")
+    def _ensure_union_mode(self) -> ty.Self:
+        """There must be a union_mode
+
+        This validator works as a guard on _coerce_union_mode to make
+        """
+        if self.union_mode is None:
+            msg = (
+                "union_mode is required. This normally indicates that you "
+                "subclasses TrackingGroup and wrote an invalid validator, but "
+                "could also be a bug with dynapydantic, so please file a bug "
+                "report with a reproducer on how you got here if you suspect "
+                "a bug."
+            )
+            raise ValueError(msg)
+
+        # Ensure the top-level fields are in-sync
+        if isinstance(self.union_mode, DiscriminatedConfig):
+            self.discriminator_field = self.union_mode.discriminator_field
+            self.discriminator_value_generator = (
+                self.union_mode.discriminator_value_generator
+            )
+        else:
+            self.discriminator_field = None
+            self.discriminator_value_generator = None
+
+        return self
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _coerce_union_mode(cls, data: ty.Any) -> ty.Any:  # noqa: ANN401
+        """Coerce flat discriminator kwargs into a DiscriminatedConfig.
+
+        Allows callers to pass ``discriminator_field`` and
+        ``discriminator_value_generator`` at the top level and transparently
+        assembles a ``DiscriminatedConfig`` from them. This avoids an extra
+        import/nesting layer for the user.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        disc_field = data.get("discriminator_field", None)
+        has_disc_field = disc_field is not None
+        union_mode = data.get("union_mode", None)
+        has_union_mode = union_mode is not None
+
+        if has_disc_field and has_union_mode:
+            msg = (
+                "Received both union_mode and discriminator_field; pass one "
+                "or the other."
+            )
+            raise ValueError(msg)
+
+        if has_disc_field and not has_union_mode:
+            # Forward arguments to DiscriminatedConfig
+            data["union_mode"] = {
+                "discriminator_field": disc_field,
+                "discriminator_value_generator": data.get(
+                    "discriminator_value_generator",
+                ),
+            }
+        elif not has_disc_field and not has_union_mode:
+            msg = "Either union_mode or discriminator_field must be given"
+            raise ValueError(msg)
+
+        return data
+
+    @property
+    def _discriminated(self) -> DiscriminatedConfig | None:
+        """Return the DiscriminatedMode config, or None if not discriminated."""
+        return (
+            self.union_mode
+            if isinstance(self.union_mode, DiscriminatedConfig)
+            else None
+        )
 
     def load_plugins(self) -> None:
         """Load plugins to discover/register additional models"""
@@ -98,38 +193,51 @@ class TrackingGroup(pydantic.BaseModel):
         """
 
         def _wrapper(cls: type[pydantic.BaseModel]) -> type[pydantic.BaseModel]:
-            disc = self.discriminator_field
-            field = cls.model_fields.get(self.discriminator_field)
-            if field is None:
-                if discriminator_value is not None:
-                    _inject_discriminator_field(cls, disc, discriminator_value)
-                elif self.discriminator_value_generator is not None:
-                    _inject_discriminator_field(
-                        cls,
-                        disc,
-                        self.discriminator_value_generator(cls),
-                    )
-                else:
-                    msg = (
-                        f"unable to determine a discriminator value for "
-                        f'{cls.__name__} in tracking group "{self.name}". No '
-                        "value was passed to register(), "
-                        "discriminator_value_generator was None and the "
-                        f'"{disc}" field was not defined.'
-                    )
-                    raise RegistrationError(msg)
-            elif (
-                discriminator_value is not None and field.default != discriminator_value
-            ):
-                msg = (
-                    f"the discriminator value for {cls.__name__} was "
-                    f'ambiguous, it was set to "{discriminator_value}" via '
-                    f'register() and "{field.default}" via the discriminator '
-                    f"field ({self.discriminator_field})."
-                )
-                raise AmbiguousDiscriminatorValueError(msg)
+            if (dm := self._discriminated) is not None:
+                disc = dm.discriminator_field
+                field = cls.model_fields.get(disc)
 
-            self._register_with_discriminator_field(cls)
+                if field is None:
+                    if discriminator_value is not None:
+                        _inject_discriminator_field(cls, disc, discriminator_value)
+                    elif dm.discriminator_value_generator is not None:
+                        _inject_discriminator_field(
+                            cls,
+                            disc,
+                            dm.discriminator_value_generator(cls),
+                        )
+                    else:
+                        msg = (
+                            f"unable to determine a discriminator value for "
+                            f'{cls.__name__} in tracking group "{self.name}". '
+                            "No value was passed to register(), "
+                            "discriminator_value_generator was None and the "
+                            f'"{disc}" field was not defined.'
+                        )
+                        raise RegistrationError(msg)
+                elif (
+                    discriminator_value is not None
+                    and field.default != discriminator_value
+                ):
+                    msg = (
+                        f"the discriminator value for {cls.__name__} was "
+                        f'ambiguous, it was set to "{discriminator_value}" via '
+                        f'register() and "{field.default}" via the '
+                        f"discriminator field ({disc})."
+                    )
+                    raise AmbiguousDiscriminatorValueError(msg)
+
+                self._register_with_discriminator_field(cls)
+            else:
+                if discriminator_value is not None:
+                    warnings.warn(
+                        f"discriminator_value={discriminator_value} was passed "
+                        f'to register() but union_mode="{self.union_mode}" '
+                        "does not use a discriminator. The value will be "
+                        "ignored.",
+                        stacklevel=2,
+                    )
+                self._register_plain(cls)
             return cls
 
         return _wrapper
@@ -142,24 +250,74 @@ class TrackingGroup(pydantic.BaseModel):
         cls
             The model to register
         """
-        disc = self.discriminator_field
-        if cls.model_fields.get(self.discriminator_field) is None:
-            if self.discriminator_value_generator is not None:
-                _inject_discriminator_field(
-                    cls,
-                    disc,
-                    self.discriminator_value_generator(cls),
-                )
-            else:
-                msg = (
-                    f"unable to determine a discriminator value for "
-                    f'{cls.__name__} in tracking group "{self.name}", '
-                    "discriminator_value_generator was None and the "
-                    f'"{disc}" field was not defined.'
-                )
-                raise RegistrationError(msg)
+        if (dm := self._discriminated) is not None:
+            disc = dm.discriminator_field
+            if cls.model_fields.get(disc) is None:
+                if dm.discriminator_value_generator is not None:
+                    _inject_discriminator_field(
+                        cls,
+                        disc,
+                        dm.discriminator_value_generator(cls),
+                    )
+                else:
+                    msg = (
+                        f"unable to determine a discriminator value for "
+                        f'{cls.__name__} in tracking group "{self.name}", '
+                        "discriminator_value_generator was None and the "
+                        f'"{disc}" field was not defined.'
+                    )
+                    raise RegistrationError(msg)
+            self._register_with_discriminator_field(cls)
+        else:
+            self._register_plain(cls)
 
-        self._register_with_discriminator_field(cls)
+    def union(
+        self,
+        *,
+        plain: ty.Literal[True] | None = None,
+        annotated: bool | None = None,
+    ) -> ty.Any:  # noqa: ANN401
+        """Return the union of all registered models
+
+        Parameters
+        ----------
+        plain
+            If set to `True`, a plain union of all members will be returned.
+            Otherwise, the returned union will be annotated in accordance with
+            the union mode.
+        annotated
+            Deprecated. Use `plain=True` when you would have used
+            `annotated=False`.
+        """
+        if annotated is not None:
+            warnings.warn(
+                "The `annotated` parameter is deprectated. Use `plain=True` to "
+                "get a plain union. By default, behavior is governed by "
+                "`union_mode`. Will be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            plain = True if not annotated else plain
+
+        union_mode = "smart" if plain else self.union_mode
+
+        if isinstance(union_mode, DiscriminatedConfig):
+            return ty.Annotated[
+                functools.reduce(
+                    operator.or_,
+                    tuple(
+                        ty.Annotated[x, pydantic.Tag(v)] for v, x in self.models.items()
+                    ),
+                ),
+                pydantic.Field(discriminator=union_mode.discriminator_field),
+            ]
+
+        plain_union = functools.reduce(operator.or_, self.models.values())
+        if union_mode == "left_to_right":
+            return ty.Annotated[plain_union, pydantic.Field(union_mode="left_to_right")]
+
+        # "smart" mode is pydantic's default behavior on a plain union
+        return plain_union
 
     def _register_with_discriminator_field(self, cls: type[pydantic.BaseModel]) -> None:
         """Register the model with the default of the discriminator field
@@ -170,7 +328,7 @@ class TrackingGroup(pydantic.BaseModel):
             The class to register, must have the disciminator field set with a
             unique default value in the group.
         """
-        disc = self.discriminator_field
+        disc = ty.cast("DiscriminatedConfig", self.union_mode).discriminator_field
         value = cls.model_fields[disc].default
         if value == pydantic_core.PydanticUndefined:
             msg = (
@@ -188,20 +346,22 @@ class TrackingGroup(pydantic.BaseModel):
 
         self.models[value] = cls
 
-    def union(self, *, annotated: bool = True) -> ty.Any:  # noqa: ANN401
-        """Return the union of all registered models"""
-        return (
-            ty.Annotated[
-                ty.Union[  # noqa: UP007
-                    # This is fundamentally incompatible with static type
-                    # checking, as this is resolved at runtime.
-                    tuple(  # type: ignore[not-a-type]
-                        ty.Annotated[x, pydantic.Tag(v)] for v, x in self.models.items()
-                    )
-                ],
-                pydantic.Field(discriminator=self.discriminator_field),
-            ]
-            if annotated
-            # type: ignore[not-a-type]
-            else ty.Union[tuple(self.models.values())]  # noqa: UP007
-        )
+    def _register_plain(self, cls: type[pydantic.BaseModel]) -> None:
+        """Register the model keyed by its class name.
+
+        Used for smart / left_to_right modes where no discriminator field
+        is involved.
+
+        Parameters
+        ----------
+        cls
+            The model to register.
+        """
+        key = str(id(cls))
+        if (other := self.models.get(key)) is not None and other is not cls:
+            msg = (
+                f'Cannot register {cls.__name__} under the "{key}" '
+                f"identifier, which is already in use by {other.__name__}."
+            )
+            raise RegistrationError(msg)
+        self.models[key] = cls

--- a/src/dynapydantic/tracking_group.py
+++ b/src/dynapydantic/tracking_group.py
@@ -91,7 +91,7 @@ class TrackingGroup(pydantic.BaseModel):
     )
 
     @pydantic.model_validator(mode="after")
-    def _ensure_union_mode(self) -> ty.Self:
+    def _ensure_union_mode(self) -> "TrackingGroup":
         """There must be a union_mode
 
         This validator works as a guard on _coerce_union_mode to make

--- a/src/dynapydantic/union_mode.py
+++ b/src/dynapydantic/union_mode.py
@@ -1,0 +1,35 @@
+"""Union mode configuration types for dynapydantic."""
+
+import typing as ty
+from collections.abc import Callable
+
+import pydantic
+
+
+class DiscriminatedConfig(pydantic.BaseModel, frozen=True, extra="forbid"):
+    """Configuration for a discriminated union.
+
+    Carries the discriminator field name and optional value generator that
+    are required when pydantic's discriminated-union validation strategy is
+    used.
+    """
+
+    discriminator_field: str = pydantic.Field(
+        description="Name of the field used to discriminate between subtypes.",
+    )
+    discriminator_value_generator: Callable[[type], str] | None = pydantic.Field(
+        None,
+        description=(
+            "A callable that produces default values for the discriminator "
+            "field when none is supplied via register()."
+        ),
+    )
+
+
+#: Literal type for the two non-discriminated union strategies.
+NonDiscriminatedMode = ty.Literal["smart", "left_to_right"]
+
+#: Full union-mode type.  Either a structured `DiscriminatedMode`
+#: (the default) or one of the plain string literals for the two
+#: non-discriminated strategies.
+UnionMode = DiscriminatedConfig | NonDiscriminatedMode

--- a/tests/test_subclass_tracking_model.py
+++ b/tests/test_subclass_tracking_model.py
@@ -106,3 +106,11 @@ def test_l2r_union() -> None:
     assert pydantic.TypeAdapter(dynapydantic.Polymorphic[Base]).validate_python(
         {"a": 1, "b": 5}
     ) == A(a=1)
+
+
+def test_invalid_union_modes() -> None:
+    """Test what happens if the user misconfigures the union mode"""
+    with pytest.raises(dynapydantic.ConfigurationError, match="union_mode"):
+
+        class Base(dynapydantic.SubclassTrackingModel, union_mode="foo"):
+            pass

--- a/tests/test_subclass_tracking_model.py
+++ b/tests/test_subclass_tracking_model.py
@@ -70,3 +70,39 @@ def test_no_config_raises() -> None:
 
         class Bad(dynapydantic.SubclassTrackingModel):
             pass
+
+
+def test_smart_union() -> None:
+    """Test a smart union"""
+
+    class Base(dynapydantic.SubclassTrackingModel, union_mode="smart"):
+        pass
+
+    class A(Base):
+        a: int
+
+    class B(Base):
+        a: int
+        b: int
+
+    assert pydantic.TypeAdapter(dynapydantic.Polymorphic[Base]).validate_python(
+        {"a": 1, "b": 5}
+    ) == B(a=1, b=5)
+
+
+def test_l2r_union() -> None:
+    """Test a left-to-right union"""
+
+    class Base(dynapydantic.SubclassTrackingModel, union_mode="left_to_right"):
+        pass
+
+    class A(Base):
+        a: int
+
+    class B(Base):
+        a: int
+        b: int
+
+    assert pydantic.TypeAdapter(dynapydantic.Polymorphic[Base]).validate_python(
+        {"a": 1, "b": 5}
+    ) == A(a=1)

--- a/tests/test_tracking_group.py
+++ b/tests/test_tracking_group.py
@@ -1,6 +1,7 @@
 """Unit test for TrackingGroup"""
 
 import typing as ty
+from unittest import mock
 
 import pydantic
 import pytest
@@ -8,10 +9,28 @@ import pytest
 import dynapydantic
 
 
-def test_tracking_group() -> None:
-    """Test basic usage of TrackingGroup"""
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"discriminator_field": "name"}, id="inline-field-kwarg"),
+        pytest.param(
+            {"union_mode": {"discriminator_field": "name"}},
+            id="union-mode-dict",
+        ),
+        pytest.param(
+            {
+                "union_mode": dynapydantic.DiscriminatedConfig(
+                    discriminator_field="name",
+                ),
+            },
+            id="union-mode-model",
+        ),
+    ],
+)
+def test_simple_disrciminated_tracking_group(kwargs: dict[str, ty.Any]) -> None:
+    """Test basic usage of TrackingGroup to make a discriminated union"""
     # Make a simple 2 registered model setup
-    group = dynapydantic.TrackingGroup(name="Test", discriminator_field="name")
+    group = dynapydantic.TrackingGroup(name="Test", **kwargs)
 
     @group.register()
     class A(pydantic.BaseModel):
@@ -24,17 +43,131 @@ def test_tracking_group() -> None:
 
     # Make sure the models and union look good
     assert group.models == {"A": A, "B": B}
-    assert group.union(annotated=False) is ty.Union[A, B]  # noqa: UP007
+    assert group.union(plain=True) == (A | B)
 
     annotated_union = group.union()
     assert ty.get_origin(annotated_union) is ty.Annotated
     annotated_args = ty.get_args(annotated_union)
     assert len(annotated_args) == 2
+    assert annotated_args[0] == (
+        ty.Annotated[A, pydantic.Tag("A")] | ty.Annotated[B, pydantic.Tag("B")]
+    )
     assert annotated_args[1].discriminator == "name"
-    assert ty.get_origin(annotated_args[0]) is ty.Union
-    union_args = ty.get_args(annotated_args[0])
-    assert union_args[0] == ty.Annotated[A, pydantic.Tag("A")]
-    assert union_args[1] == ty.Annotated[B, pydantic.Tag("B")]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        pytest.param(
+            {}, "Either union_mode or discriminator_field must be given", id="no-args"
+        ),
+        pytest.param(
+            {
+                "discriminator_field": "foo",
+                "union_mode": {"discriminator_field": "foo"},
+            },
+            "Received both union_mode and discriminator_field; pass one or the other.",
+            id="redundant-args",
+        ),
+    ],
+)
+def test_bad_construction(kwargs: dict[str, ty.Any], match: str) -> None:
+    """Test bad construction of a tracking group"""
+    with pytest.raises(pydantic.ValidationError, match=match):
+        dynapydantic.TrackingGroup(name="test", **kwargs)
+
+
+def test_invalid_type() -> None:
+    """Test that we don't construct from garbage input"""
+    with pytest.raises(pydantic.ValidationError, match="model_type"):
+        dynapydantic.TrackingGroup.model_validate("foo")
+
+
+def test_model_validate_noop() -> None:
+    """Test that a tracking group can be copied"""
+    group = dynapydantic.TrackingGroup(name="Test", discriminator_field="name")
+    assert group.union_mode == dynapydantic.DiscriminatedConfig(
+        discriminator_field="name", discriminator_value_generator=None
+    )
+    assert group.discriminator_field == "name"
+    assert group.discriminator_value_generator is None
+
+    group2 = dynapydantic.TrackingGroup.model_validate(group)
+    assert group2 is group
+    assert group2.union_mode == dynapydantic.DiscriminatedConfig(
+        discriminator_field="name", discriminator_value_generator=None
+    )
+    assert group2.discriminator_field == "name"
+    assert group2.discriminator_value_generator is None
+
+
+def test_smart_union_mode() -> None:
+    """Test making a tracking group with the "smart" union"""
+    group = dynapydantic.TrackingGroup(name="Test", union_mode="smart")
+
+    @group.register()
+    class A(pydantic.BaseModel):
+        a: int
+
+    class B(pydantic.BaseModel):
+        a: int
+        b: int
+
+    group.register_model(B)
+
+    with pytest.warns(match="The value will be ignored"):
+
+        @group.register("C")
+        class C(pydantic.BaseModel):
+            c: int
+
+    assert group.union() == A | B | C
+    assert group.union(plain=True) == A | B | C
+    with pytest.warns(DeprecationWarning, match="annotated"):
+        assert group.union(annotated=False) == A | B | C
+
+    assert pydantic.TypeAdapter(group.union()).validate_python({"a": 1, "b": 5}) == B(
+        a=1, b=5
+    )
+
+
+def test_left_to_right_union_mode() -> None:
+    """Test a left-to-right union"""
+    group = dynapydantic.TrackingGroup(name="Test", union_mode="left_to_right")
+
+    @group.register()
+    class A(pydantic.BaseModel):
+        a: int
+
+    @group.register()
+    class B(pydantic.BaseModel):
+        a: int
+        b: int | None = None
+
+    u = group.union()
+    assert ty.get_origin(u) is ty.Annotated
+    args = ty.get_args(u)
+    assert args[0] == A | B
+
+    assert pydantic.TypeAdapter(group.union()).validate_python({"a": 1, "b": 5}) == A(
+        a=1
+    )
+
+
+def test_ensure_union_mode() -> None:
+    """Test that there is a guard against no union_mode"""
+
+    class MyTrackingGroup(dynapydantic.TrackingGroup):
+        @pydantic.model_validator(mode="before")
+        @classmethod
+        def _coerce_union_mode(cls, data: ty.Any) -> ty.Any:  # noqa: ANN401
+            if isinstance(data, dict):
+                data.pop("union_mode", None)
+                data.pop("discriminator_field", None)
+            return data
+
+    with pytest.raises(pydantic.ValidationError, match="union_mode is required"):
+        MyTrackingGroup(name="test", union_mode="smart")
 
 
 def test_no_default_val() -> None:
@@ -63,6 +196,30 @@ def test_duplicate_discriminators() -> None:
         @group.register("A")
         class B(pydantic.BaseModel):
             pass
+
+
+def test_duplicate_models_no_discriminated() -> None:
+    """Test the super pessimistic guard in plain registration"""
+    group = dynapydantic.TrackingGroup(name="Test", union_mode="smart")
+
+    @group.register()
+    class A(pydantic.BaseModel):
+        a: int
+
+    class B(pydantic.BaseModel):
+        b: int
+
+    with (
+        mock.patch("builtins.id", return_value=id(A)),
+        pytest.raises(
+            dynapydantic.RegistrationError,
+            match=(
+                r'Cannot register .*B under the ".*" identifier, which is '
+                r"already in use by .*A"
+            ),
+        ),
+    ):
+        group.register_model(B)
 
 
 def test_no_discriminator() -> None:

--- a/tests/test_tracking_group.py
+++ b/tests/test_tracking_group.py
@@ -44,6 +44,8 @@ def test_simple_disrciminated_tracking_group(kwargs: dict[str, ty.Any]) -> None:
     # Make sure the models and union look good
     assert group.models == {"A": A, "B": B}
     assert group.union(plain=True) == (A | B)
+    with pytest.warns(DeprecationWarning, match="annotated"):
+        assert group.union(annotated=False) == (A | B)
 
     annotated_union = group.union()
     assert ty.get_origin(annotated_union) is ty.Annotated

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -80,15 +80,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
-]
-
-[[package]]
-name = "cfgv"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
 ]
 
 [[package]]
@@ -320,15 +311,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distlib"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
-]
-
-[[package]]
 name = "docopt"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -364,7 +346,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pip" },
-    { name = "pre-commit" },
+    { name = "prek" },
     { name = "pymdown-extensions" },
     { name = "pyrefly" },
     { name = "pytest" },
@@ -386,7 +368,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.6.15" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
     { name = "pip", specifier = ">=25.1.1" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "prek", specifier = ">=0.3.8" },
     { name = "pymdown-extensions", specifier = ">=10.16" },
     { name = "pyrefly", specifier = ">=0.44.1" },
     { name = "pytest", specifier = ">=8.4.1" },
@@ -415,15 +397,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
-]
-
-[[package]]
-name = "filelock"
-version = "3.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
 ]
 
 [[package]]
@@ -460,15 +433,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/99/52/b05f582287f887f58a1738183d6dd0e799842b83f6f60d65c77ba90cee31/griffe_pydantic-1.1.8.tar.gz", hash = "sha256:72cde69c74c70f3dc0385a7a5243c736cd6bf6fcf8a41cae497383defe107041", size = 43425, upload-time = "2025-10-14T09:12:37.693Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/e3/94b2e39d841a1c07b586903177d3ee802c8ae87567449a541d14028eb657/griffe_pydantic-1.1.8-py3-none-any.whl", hash = "sha256:22212c94216e03bf43d30ff3bc79cd53fb973ae2fe81d8b7510242232a1e6764", size = 12852, upload-time = "2025-10-14T09:12:36.23Z" },
-]
-
-[[package]]
-name = "identify"
-version = "2.6.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311, upload-time = "2025-10-02T17:43:40.631Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757", size = 99183, upload-time = "2025-10-02T17:43:39.137Z" },
 ]
 
 [[package]]
@@ -786,15 +750,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -858,19 +813,27 @@ wheels = [
 ]
 
 [[package]]
-name = "pre-commit"
-version = "4.5.0"
+name = "prek"
+version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/9b/6a4ffb4ed980519da959e1cf3122fc6cb41211daa58dbae1c73c0e519a37/pre_commit-4.5.0.tar.gz", hash = "sha256:dc5a065e932b19fc1d4c653c6939068fe54325af8e741e74e88db4d28a4dd66b", size = 198428, upload-time = "2025-11-22T21:02:42.304Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/ee/03e8180e3fda9de25b6480bd15cc2bde40d573868d50648b0e527b35562f/prek-0.3.8.tar.gz", hash = "sha256:434a214256516f187a3ab15f869d950243be66b94ad47987ee4281b69643a2d9", size = 400224, upload-time = "2026-03-23T08:23:35.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/c4/b2d28e9d2edf4f1713eb3c29307f1a63f3d67cf09bdda29715a36a68921a/pre_commit-4.5.0-py2.py3-none-any.whl", hash = "sha256:25e2ce09595174d9c97860a95609f9f852c0614ba602de3561e267547f2335e1", size = 226429, upload-time = "2025-11-22T21:02:40.836Z" },
+    { url = "https://files.pythonhosted.org/packages/00/84/40d2ddf362d12c4cd4a25a8c89a862edf87cdfbf1422aa41aac8e315d409/prek-0.3.8-py3-none-linux_armv6l.whl", hash = "sha256:6fb646ada60658fa6dd7771b2e0fb097f005151be222f869dada3eb26d79ed33", size = 5226646, upload-time = "2026-03-23T08:23:18.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/52/7308a033fa43b7e8e188797bd2b3b017c0f0adda70fa7af575b1f43ea888/prek-0.3.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f3d7fdadb15efc19c09953c7a33cf2061a70f367d1e1957358d3ad5cc49d0616", size = 5620104, upload-time = "2026-03-23T08:23:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b1/f106ac000a91511a9cd80169868daf2f5b693480ef5232cec5517a38a512/prek-0.3.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:72728c3295e79ca443f8c1ec037d2a5b914ec73a358f69cf1bc1964511876bf8", size = 5199867, upload-time = "2026-03-23T08:23:38.066Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e9/970713f4b019f69de9844e1bab37b8ddb67558e410916f4eb5869a696165/prek-0.3.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:48efc28f2f53b5b8087efca9daaed91572d62df97d5f24a1c7a087fecb5017de", size = 5441801, upload-time = "2026-03-23T08:23:32.617Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a4/7ef44032b181753e19452ec3b09abb3a32607cf6b0a0508f0604becaaf2b/prek-0.3.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f6ca9d63bacbc448a5c18e955c78d3ac5176c3a17c3baacdd949b1a623e08a36", size = 5155107, upload-time = "2026-03-23T08:23:31.021Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/77/4d9c8985dbba84149760785dfe07093ea1e29d710257dfb7c89615e2234c/prek-0.3.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1000f7029696b4fe712fb1fefd4c55b9c4de72b65509c8e50296370a06f9dc3f", size = 5566541, upload-time = "2026-03-23T08:23:45.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1a/81e6769ac1f7f8346d09ce2ab0b47cf06466acd9ff72e87e5d1f0d98cd32/prek-0.3.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ff0bed0e2c1286522987d982168a86cbbd0d069d840506a46c9fda983515517", size = 6552991, upload-time = "2026-03-23T08:23:21.958Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fa/ce2df0dd2dc75a9437a52463239d0782998943d7b04e191fb89b83016c34/prek-0.3.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fb087ac0ffda3ac65bbbae9a38326a7fd27ee007bb4a94323ce1eb539d8bbec", size = 5832972, upload-time = "2026-03-23T08:23:20.258Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6b/9d4269df9073216d296244595a21c253b6475dfc9076c0bd2906be7a436c/prek-0.3.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2e1e5e206ff7b31bd079cce525daddc96cd6bc544d20dc128921ad92f7a4c85d", size = 5448371, upload-time = "2026-03-23T08:23:41.835Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1d/1e4d8a78abefa5b9d086e5a9f1638a74b5e540eec8a648d9946707701f29/prek-0.3.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:dcea3fe23832a4481bccb7c45f55650cb233be7c805602e788bb7dba60f2d861", size = 5270546, upload-time = "2026-03-23T08:23:24.231Z" },
+    { url = "https://files.pythonhosted.org/packages/77/07/34f36551a6319ae36e272bea63a42f59d41d2d47ab0d5fb00eb7b4e88e87/prek-0.3.8-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:4d25e647e9682f6818ab5c31e7a4b842993c14782a6ffcd128d22b784e0d677f", size = 5124032, upload-time = "2026-03-23T08:23:26.368Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/01/6d544009bb655e709993411796af77339f439526db4f3b3509c583ad8eb9/prek-0.3.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:de528b82935e33074815acff3c7c86026754d1212136295bc88fe9c43b4231d5", size = 5432245, upload-time = "2026-03-23T08:23:47.877Z" },
+    { url = "https://files.pythonhosted.org/packages/54/96/1237ee269e9bfa283ffadbcba1f401f48a47aed2b2563eb1002740d6079d/prek-0.3.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6d660f1c25a126e6d9f682fe61449441226514f412a4469f5d71f8f8cad56db2", size = 5950550, upload-time = "2026-03-23T08:23:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6b/a574411459049bc691047c9912f375deda10c44a707b6ce98df2b658f0b3/prek-0.3.8-py3-none-win32.whl", hash = "sha256:b0c291c577615d9f8450421dff0b32bfd77a6b0d223ee4115a1f820cb636fdf1", size = 4949501, upload-time = "2026-03-23T08:23:16.338Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b4/46b59fe49f635acd9f6530778ce577f9d8b49452835726a5311ffc902c67/prek-0.3.8-py3-none-win_amd64.whl", hash = "sha256:bc147fdbdd4ec33fc7a987b893ecb69b1413ac100d95c9889a70f3fd58c73d06", size = 5346551, upload-time = "2026-03-23T08:23:34.501Z" },
+    { url = "https://files.pythonhosted.org/packages/53/05/9cca1708bb8c65264124eb4b04251e0f65ce5bfc707080bb6b492d5a0df7/prek-0.3.8-py3-none-win_arm64.whl", hash = "sha256:a2614647aeafa817a5802ccb9561e92eedc20dcf840639a1b00826e2c2442515", size = 5190872, upload-time = "2026-03-23T08:23:29.463Z" },
 ]
 
 [[package]]
@@ -1440,21 +1403,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "20.35.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799, upload-time = "2025-10-29T06:57:40.511Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b", size = 6005095, upload-time = "2025-10-29T06:57:37.598Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds support for "smart" and "left_to_right" unions.

These can be accessed via the "union_mode" parameter on SubclassTrackingModel and TrackingGroup.

Example:
```python
import typing as ty

import dynapydantic
import pydantic

class Base(
    dynapydantic.SubclassTrackingModel,
    union_mode="smart",
):  
    """dynapydantic.Polymorphic[Base] will be a "smart" A | B"""

class A(Base):
    a: int

class B(Base):
    b: int

class Model(pydantic.BaseModel):
    field: dynapydantic.Polymorphic[Base]

print(Model(field={"b": 5}))
# field=B(b=5)
```
