### PR TITLE
Add support for implicit Polymorphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,87 @@ class Model(pydantic.BaseModel):
 print(Model(field={"b": 5}))
 # field=B(b=5)
 ```
+
+### When are unions realized?
+
+When using `TrackingModel` directly, there is only one option for when the union
+is realized, which is the moment you call `.union()`. At this point, any classes
+that have been registered will be present in the union. Registration of
+additional classes after a call to `.union()` will not update the returned
+union from a previous call, so it is important to consider order of operations.
+
+When using `SubclassTrackingModel`, there are more options and each comes with
+their own tradeoffs:
+
+1. Calling `.union()` directly: This functions exactly as it does with
+    `TrackingGroup`. This option is the "most eager" option, but is the most
+    sensitive with order of operations. In addition, type checkers will not
+    understand this method, as they will complain about calling a function in a
+    type annotation (rightfully so).
+
+    Despite the tradeoffs, this option can be desireable for applications that
+    inspect field annotations directly. This normally arises in user-implemented
+    model reflection code and with
+    [`pydantic_settings`](https://pydantic.dev/docs/validation/latest/api/pydantic_settings/#_top).
+
+2. Using `dynapydantic.Polymorphic[T]`: This method will defer the union
+    realization slightly, into the schema generation step for the model. The
+    difference between this and option 1 is slight and subtle, but does have an
+    affect with recursive models. Consider the following:
+
+    ```python
+    import dynapydantic
+    import pydantic
+
+    class Base(dynapydantic.SubclassTrackingModel, union_mode="smart"):
+        pass
+
+    class A(Base, extra="forbid"):
+        a: int
+
+    class B(Base, extra="forbid"):
+        other: dynapydantic.Polymorphic[Base]
+
+    B(other={"other": {"other": {"a": 2}}}) # ValidationError (union only has A)
+
+    B.model_rebuild(force=True)
+    B(other={"other": {"other": {"a": 2}}}) # B(other=B(other=B(other=A(a=2))))
+    ```
+    if we used `Base.union()` directly, the `model_rebuild()` call would do
+    nothing, as the union had already been realized. To accomplish the same
+    thing with `.union()`, we would have to use a forward reference, like
+    `"BUnion"` then then call `.union()` right before the `model_rebuild()`
+    calls.
+
+    Unlike direct `union()` calls, the type checker can at least infer the field
+    to be a subclass of `Base`, which is a vast improvement over a type error.
+
+3. **EXPERIMENTAL** Using `implicit_polymorphic`: If `implicit_polymorphic=True`
+    is passed to a `SubclassTrackingModel`, then union realization is deferred
+    to model validation time, making the process robust to order of operations.
+    This reduces the previous example down to:
+
+    ```python
+    import dynapydantic
+    import pydantic
+
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        union_mode="smart",
+        implicit_polymorphic=True,
+    ):
+        pass
+
+    class A(Base, extra="forbid"):
+        a: int
+
+    class B(Base, extra="forbid"):
+        other: Base
+
+    B(other={"other": {"other": {"a": 2}}}) # B(other=B(other=B(other=A(a=2))))
+    ```
+
+    This option has the cleanest syntax, but does incur a runtime penalty for
+    potentially multiple schema compilations and the need for a field validator
+    function, whereas options 1 and 2 can produce static schema. Like option 2,
+    the field is able to be interpreted by type checkers as the base class.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dynapydantic"
-version = "0.3.0"
+version = "0.4.0a1"
 description = "Dyanmic pydantic models"
 readme = "README.md"
 authors = [

--- a/src/dynapydantic/polymorphic.py
+++ b/src/dynapydantic/polymorphic.py
@@ -30,4 +30,4 @@ else:
             if getattr(item, "__DYNAPYDANTIC_IMPLICIT_POLYMORPHIC__", False):
                 return item
 
-            return ty.Annotated[item, SubclassTrackingModel.PydanticAdaptor]
+            return ty.Annotated[item, SubclassTrackingModel.PydanticAdapter]

--- a/src/dynapydantic/polymorphic.py
+++ b/src/dynapydantic/polymorphic.py
@@ -26,4 +26,8 @@ else:
             if not isinstance(item, type):
                 msg = f"dynapydantic.Polymorphic must be given a type, not {item}"
                 raise TypeError(msg)
+
+            if getattr(item, "__DYNAPYDANTIC_IMPLICIT_POLYMORPHIC__", False):
+                return item
+
             return ty.Annotated[item, SubclassTrackingModel.PydanticAdaptor]

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -67,8 +67,14 @@ class SubclassTrackingModel(pydantic.BaseModel):
             },
         )
 
+    # This method is too complex, here's the plan to simplify it:
+    # We're polluting this models attributes by injecting and forwarding methods
+    # from tracking group. As a result, we're limiting the possible field names
+    # that these models can have. These should be free functions. We're going
+    # to deprecate the methods to give people a release cycle to migrate off.
+    # We should be able to remove the noqa after these are removed.
     @classmethod
-    def __pydantic_init_subclass__(  # noqa: C901 (fix this!)
+    def __pydantic_init_subclass__(  # noqa: C901
         cls,
         *args,
         exclude_from_union: bool | None = None,
@@ -88,10 +94,6 @@ class SubclassTrackingModel(pydantic.BaseModel):
             )
 
             cls.__DYNAPYDANTIC_IMPLICIT_POLYMORPHIC__ = implicit_polymorphic
-            cls.__DYNAPYDANTIC_SCHEMA_GENERATION__: ty.ClassVar[int] = -1
-            cls.__DYNAPYDANTIC_ADAPTER__: ty.ClassVar[pydantic.TypeAdapter | None] = (
-                None
-            )
 
             if isinstance((tc := getattr(cls, "tracking_config", None)), TrackingGroup):
                 cls.__DYNAPYDANTIC__ = tc
@@ -162,7 +164,7 @@ class SubclassTrackingModel(pydantic.BaseModel):
                     source_type = _assert_stm_subclass(source_type)
 
                     def _validate(value: ty.Any) -> ty.Any:  # noqa: ANN401
-                        return _ensure_adapter(source_type).validate_python(value)
+                        return _get_adapter(source_type).validate_python(value)
 
                     def _serialize(
                         value: pydantic.BaseModel,
@@ -191,7 +193,7 @@ class SubclassTrackingModel(pydantic.BaseModel):
                 ) -> JsonSchemaValue:
                     if SubclassTrackingModel not in cls.__bases__:
                         return handler(core_schema)
-                    return handler(_ensure_adapter(cls).core_schema)
+                    return handler(_get_adapter(cls).core_schema)
 
                 cls.__get_pydantic_json_schema__ = classmethod(_gpjs)  # type: ignore[bad-assignment]
 
@@ -234,19 +236,11 @@ def _assert_stm_subclass(
     return t
 
 
-def _ensure_adapter(
+def _get_adapter(
     source_type: type[SubclassTrackingModel],
 ) -> pydantic.TypeAdapter:
-    group = source_type.__DYNAPYDANTIC__
-    if group.generation != source_type.__DYNAPYDANTIC_SCHEMA_GENERATION__:
-        try:
-            source_type.__DYNAPYDANTIC_ADAPTER__ = pydantic.TypeAdapter(group.union())
-        except Error as e:
-            err_t = "dynapydantic_error"
-            raise PydanticCustomError(err_t, "{e}", {"e": str(e)}) from e
-        source_type.__DYNAPYDANTIC_SCHEMA_GENERATION__ = group.generation
-
-    # casting because the if statement ensures it is non-None (because
-    # __DYNAPYDANTIC_SCHEMA_GENERATION__ starts at -1 and generation
-    # increments from 0.
-    return ty.cast("pydantic.TypeAdapter", source_type.__DYNAPYDANTIC_ADAPTER__)
+    try:
+        return source_type.__DYNAPYDANTIC__.type_adapter
+    except Error as e:
+        err_t = "dynapydantic_error"
+        raise PydanticCustomError(err_t, "{e}", {"e": str(e)}) from e

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -30,9 +30,6 @@ def direct_children_of_base_in_mro(derived: type, base: type) -> list[type]:
     return [cls for cls in derived.__mro__ if cls is not base and base in cls.__bases__]
 
 
-SubT = ty.TypeVar("SubT", bound="SubclassTrackingModel")
-
-
 class SubclassTrackingModel(pydantic.BaseModel):
     """Subclass-tracking BaseModel
 
@@ -54,6 +51,23 @@ class SubclassTrackingModel(pydantic.BaseModel):
         packages to discover additional subclasses. See
         [`TrackingGroup.load_plugins()`][dynapydantic.TrackingGroup.load_plugins]
         for more details.
+
+    Similar to `BaseModel`, `SubclassTrackingModel` can take arguments in the
+    class declaration. Arguments from `BaseModel` will be forwarded.
+    Additionally, any fields from `TrackingGroup` will be forwarded to the
+    internal `TrackingGroup` instance. The following additional arguments are
+    supported:
+
+    1. `exclude_from_union`: This flag is intended to be used with descendents
+           of `SubclassTrackingModel`. If `True`, this subclass will be omitted
+           from tracking.
+    2. `implicit_polymorphic`: This flag is intended to be used with direct
+           descendents of `SubclassTrackingModel`. If `True`, then the core
+           schema of this class will be overridden. This allows polymorphic
+           parsing to occur without the use of
+           [`Polymorphic`][dynapydantic.Polymorphic]. In addition, it is not
+           necessary to call `model_rebuild` on recursive models. This feature
+           is currently **EXPERIMENTAL** and does incur a runtime penalty.
     """
 
     def __init_subclass__(cls, *args, **kwargs) -> None:
@@ -158,52 +172,13 @@ class SubclassTrackingModel(pydantic.BaseModel):
             cls.registered_subclasses = staticmethod(_subclasses)
 
             if implicit_polymorphic:
+                cls.__get_pydantic_core_schema__ = classmethod(  # type: ignore[bad-assignment]
+                    _get_pydantic_core_schema
+                )
 
-                def _gpcs(
-                    _cls: type[SubclassTrackingModel],
-                    source_type: type[pydantic.BaseModel],
-                    handler: GetCoreSchemaHandler,
-                    /,
-                ) -> core_schema.CoreSchema:
-                    if SubclassTrackingModel not in _cls.__bases__:
-                        return handler(source_type)
-
-                    source_type = _assert_stm_subclass(source_type)
-
-                    def _validate(value: ty.Any) -> ty.Any:  # noqa: ANN401
-                        return _get_adapter(source_type).validate_python(value)
-
-                    def _serialize(
-                        value: pydantic.BaseModel,
-                        info: core_schema.SerializationInfo,
-                    ) -> dict[str, ty.Any]:
-                        return value.model_dump(mode=info.mode)
-
-                    return core_schema.no_info_plain_validator_function(
-                        _validate,
-                        serialization=core_schema.plain_serializer_function_ser_schema(
-                            _serialize,
-                            info_arg=True,
-                            when_used="unless-none",
-                            return_schema=core_schema.dict_schema(
-                                core_schema.str_schema(), core_schema.any_schema()
-                            ),
-                        ),
-                    )
-
-                cls.__get_pydantic_core_schema__ = classmethod(_gpcs)  # type: ignore[bad-assignment]
-
-                def _gpjs(
-                    _cls: type[SubT],
-                    _core_schema: core_schema.CoreSchema,
-                    handler: GetJsonSchemaHandler,
-                    /,
-                ) -> JsonSchemaValue:
-                    if SubclassTrackingModel in _cls.__bases__:
-                        return handler(_get_adapter(_cls).core_schema)
-                    return handler(_core_schema)
-
-                cls.__get_pydantic_json_schema__ = classmethod(_gpjs)  # type: ignore[bad-assignment]
+                cls.__get_pydantic_json_schema__ = classmethod(  # type: ignore[bad-assignment]
+                    _get_pydantic_json_schema
+                )
 
             return
 
@@ -252,3 +227,49 @@ def _get_adapter(
     except Error as e:
         err_t = "dynapydantic_error"
         raise PydanticCustomError(err_t, "{e}", {"e": str(e)}) from e
+
+
+def _get_pydantic_core_schema(
+    cls: type[SubclassTrackingModel],
+    source_type: type[pydantic.BaseModel],
+    handler: GetCoreSchemaHandler,
+    /,
+) -> core_schema.CoreSchema:
+    """Get the pydantic core schema for this type"""
+    if SubclassTrackingModel not in cls.__bases__:
+        return handler(source_type)
+
+    source_type = _assert_stm_subclass(source_type)
+
+    def _validate(value: ty.Any) -> ty.Any:  # noqa: ANN401
+        return _get_adapter(source_type).validate_python(value)
+
+    def _serialize(
+        value: pydantic.BaseModel,
+        info: core_schema.SerializationInfo,
+    ) -> dict[str, ty.Any]:
+        return value.model_dump(mode=info.mode)
+
+    return core_schema.no_info_plain_validator_function(
+        _validate,
+        serialization=core_schema.plain_serializer_function_ser_schema(
+            _serialize,
+            info_arg=True,
+            when_used="unless-none",
+            return_schema=core_schema.dict_schema(
+                core_schema.str_schema(), core_schema.any_schema()
+            ),
+        ),
+    )
+
+
+def _get_pydantic_json_schema(
+    cls: type[SubclassTrackingModel],
+    cs: core_schema.CoreSchema,
+    handler: GetJsonSchemaHandler,
+    /,
+) -> JsonSchemaValue:
+    """Get the pydantic JSON schema for this type"""
+    if SubclassTrackingModel in cls.__bases__:
+        return handler(_get_adapter(cls).core_schema)
+    return handler(cs)

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -208,8 +208,8 @@ class SubclassTrackingModel(pydantic.BaseModel):
         for base in supers:
             base.__DYNAPYDANTIC__.register_model(cls)
 
-    class PydanticAdaptor:
-        """Pydantic type adaptor for SubclassTrackingModel"""
+    class PydanticAdapter:
+        """Pydantic type adapter for SubclassTrackingModel"""
 
         @staticmethod
         def __get_pydantic_core_schema__(

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -4,11 +4,12 @@ import inspect
 import typing as ty
 
 import pydantic
-from pydantic import GetCoreSchemaHandler
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic.errors import PydanticSchemaGenerationError
-from pydantic_core import core_schema
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import PydanticCustomError, core_schema
 
-from .exceptions import ConfigurationError
+from .exceptions import ConfigurationError, Error
 from .tracking_group import TrackingGroup
 
 
@@ -67,10 +68,11 @@ class SubclassTrackingModel(pydantic.BaseModel):
         )
 
     @classmethod
-    def __pydantic_init_subclass__(
+    def __pydantic_init_subclass__(  # noqa: C901 (fix this!)
         cls,
         *args,
         exclude_from_union: bool | None = None,
+        implicit_polymorphic: bool | None = None,
         **kwargs,
     ) -> None:
         """Pydantic subclass hook"""
@@ -83,6 +85,12 @@ class SubclassTrackingModel(pydantic.BaseModel):
                     for k, v in kwargs.items()
                     if k not in TrackingGroup.model_fields
                 },
+            )
+
+            cls.__DYNAPYDANTIC_IMPLICIT_POLYMORPHIC__ = implicit_polymorphic
+            cls.__DYNAPYDANTIC_SCHEMA_GENERATION__: ty.ClassVar[int] = -1
+            cls.__DYNAPYDANTIC_ADAPTER__: ty.ClassVar[pydantic.TypeAdapter | None] = (
+                None
             )
 
             if isinstance((tc := getattr(cls, "tracking_config", None)), TrackingGroup):
@@ -140,6 +148,53 @@ class SubclassTrackingModel(pydantic.BaseModel):
 
             cls.registered_subclasses = staticmethod(_subclasses)
 
+            if implicit_polymorphic:
+
+                def _gpcs(
+                    cls: type[SubclassTrackingModel],
+                    source_type: type[pydantic.BaseModel],
+                    handler: GetCoreSchemaHandler,
+                    /,
+                ) -> core_schema.CoreSchema:
+                    if SubclassTrackingModel not in cls.__bases__:
+                        return handler(source_type)
+
+                    source_type = _assert_stm_subclass(source_type)
+
+                    def _validate(value: ty.Any) -> ty.Any:  # noqa: ANN401
+                        return _ensure_adapter(source_type).validate_python(value)
+
+                    def _serialize(
+                        value: pydantic.BaseModel,
+                        info: core_schema.SerializationInfo,
+                    ) -> dict[str, ty.Any]:
+                        return value.model_dump(mode=info.mode)
+
+                    return core_schema.no_info_plain_validator_function(
+                        _validate,
+                        serialization=core_schema.plain_serializer_function_ser_schema(
+                            _serialize,
+                            info_arg=True,
+                            when_used="unless-none",
+                            return_schema=core_schema.dict_schema(
+                                core_schema.str_schema(), core_schema.any_schema()
+                            ),
+                        ),
+                    )
+
+                cls.__get_pydantic_core_schema__ = classmethod(_gpcs)  # type: ignore[bad-assignment]
+
+                def _gpjs(
+                    cls: type[SubclassTrackingModel],
+                    core_schema: core_schema.CoreSchema,
+                    handler: GetJsonSchemaHandler,
+                ) -> JsonSchemaValue:
+                    if SubclassTrackingModel not in cls.__bases__:
+                        return handler(core_schema)
+                    return handler(_ensure_adapter(cls).core_schema)
+
+                cls.__get_pydantic_json_schema__ = classmethod(_gpjs)  # type: ignore[bad-assignment]
+
             return
 
         super().__pydantic_init_subclass__(*args, **kwargs)
@@ -160,13 +215,38 @@ class SubclassTrackingModel(pydantic.BaseModel):
             handler: GetCoreSchemaHandler,
         ) -> core_schema.CoreSchema:
             """Get the pydantic schema for this type"""
-            if not isinstance(source_type, type) or not issubclass(
-                source_type,
-                SubclassTrackingModel,
-            ):
-                msg = (
-                    f"{source_type} was not a SubclassTrackingModel, "
-                    "so it is incompatible with dynapydantic.Polymorphic"
-                )
-                raise PydanticSchemaGenerationError(msg)
+            source_type = _assert_stm_subclass(source_type)
             return handler(source_type.union())
+
+
+def _assert_stm_subclass(
+    t: ty.Any,  # noqa: ANN401
+) -> type[SubclassTrackingModel]:
+    if not isinstance(t, type) or not issubclass(
+        t,
+        SubclassTrackingModel,
+    ):
+        msg = (
+            f"{t} was not a SubclassTrackingModel, "
+            "so it is incompatible with dynapydantic.Polymorphic"
+        )
+        raise PydanticSchemaGenerationError(msg)
+    return t
+
+
+def _ensure_adapter(
+    source_type: type[SubclassTrackingModel],
+) -> pydantic.TypeAdapter:
+    group = source_type.__DYNAPYDANTIC__
+    if group.generation != source_type.__DYNAPYDANTIC_SCHEMA_GENERATION__:
+        try:
+            source_type.__DYNAPYDANTIC_ADAPTER__ = pydantic.TypeAdapter(group.union())
+        except Error as e:
+            err_t = "dynapydantic_error"
+            raise PydanticCustomError(err_t, "{e}", {"e": str(e)}) from e
+        source_type.__DYNAPYDANTIC_SCHEMA_GENERATION__ = group.generation
+
+    # casting because the if statement ensures it is non-None (because
+    # __DYNAPYDANTIC_SCHEMA_GENERATION__ starts at -1 and generation
+    # increments from 0.
+    return ty.cast("pydantic.TypeAdapter", source_type.__DYNAPYDANTIC_ADAPTER__)

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -30,6 +30,9 @@ def direct_children_of_base_in_mro(derived: type, base: type) -> list[type]:
     return [cls for cls in derived.__mro__ if cls is not base and base in cls.__bases__]
 
 
+SubT = ty.TypeVar("SubT", bound="SubclassTrackingModel")
+
+
 class SubclassTrackingModel(pydantic.BaseModel):
     """Subclass-tracking BaseModel
 
@@ -93,14 +96,18 @@ class SubclassTrackingModel(pydantic.BaseModel):
                 },
             )
 
-            cls.__DYNAPYDANTIC_IMPLICIT_POLYMORPHIC__ = implicit_polymorphic
+            cls.__DYNAPYDANTIC_IMPLICIT_POLYMORPHIC__: ty.ClassVar[bool] = (
+                implicit_polymorphic if implicit_polymorphic is not None else False
+            )
 
             if isinstance((tc := getattr(cls, "tracking_config", None)), TrackingGroup):
-                cls.__DYNAPYDANTIC__ = tc
+                cls.__DYNAPYDANTIC__: ty.ClassVar[TrackingGroup] = tc
             else:
                 try:
-                    cls.__DYNAPYDANTIC__: TrackingGroup = TrackingGroup.model_validate(
-                        {"name": f"{cls.__name__}-subclasses"} | kwargs,
+                    cls.__DYNAPYDANTIC__: ty.ClassVar[TrackingGroup] = (
+                        TrackingGroup.model_validate(
+                            {"name": f"{cls.__name__}-subclasses"} | kwargs,
+                        )
                     )
                 except pydantic.ValidationError as e:
                     msg = (
@@ -153,12 +160,12 @@ class SubclassTrackingModel(pydantic.BaseModel):
             if implicit_polymorphic:
 
                 def _gpcs(
-                    cls: type[SubclassTrackingModel],
+                    _cls: type[SubclassTrackingModel],
                     source_type: type[pydantic.BaseModel],
                     handler: GetCoreSchemaHandler,
                     /,
                 ) -> core_schema.CoreSchema:
-                    if SubclassTrackingModel not in cls.__bases__:
+                    if SubclassTrackingModel not in _cls.__bases__:
                         return handler(source_type)
 
                     source_type = _assert_stm_subclass(source_type)
@@ -187,13 +194,14 @@ class SubclassTrackingModel(pydantic.BaseModel):
                 cls.__get_pydantic_core_schema__ = classmethod(_gpcs)  # type: ignore[bad-assignment]
 
                 def _gpjs(
-                    cls: type[SubclassTrackingModel],
-                    core_schema: core_schema.CoreSchema,
+                    _cls: type[SubT],
+                    _core_schema: core_schema.CoreSchema,
                     handler: GetJsonSchemaHandler,
+                    /,
                 ) -> JsonSchemaValue:
-                    if SubclassTrackingModel not in cls.__bases__:
-                        return handler(core_schema)
-                    return handler(_get_adapter(cls).core_schema)
+                    if SubclassTrackingModel in _cls.__bases__:
+                        return handler(_get_adapter(_cls).core_schema)
+                    return handler(_core_schema)
 
                 cls.__get_pydantic_json_schema__ = classmethod(_gpjs)  # type: ignore[bad-assignment]
 

--- a/src/dynapydantic/tracking_group.py
+++ b/src/dynapydantic/tracking_group.py
@@ -103,6 +103,16 @@ class TrackingGroup(pydantic.BaseModel):
         description="The tracked models",
     )
 
+    _generation: int = pydantic.PrivateAttr(default=0)
+
+    @property
+    def generation(self) -> int:
+        """The generation of the tracking group.
+
+        This is a counter that increments every time a new registration occurs
+        """
+        return self._generation
+
     @pydantic.model_validator(mode="after")
     def _ensure_union_mode(self) -> "TrackingGroup":
         """There must be a union_mode
@@ -396,14 +406,7 @@ class TrackingGroup(pydantic.BaseModel):
             )
             raise RegistrationError(msg)
 
-        if (other := self.models.get(value)) is not None and other is not cls:
-            msg = (
-                f'Cannot register {cls.__name__} under the "{value}" '
-                f"identifier, which is already in use by {other.__name__}."
-            )
-            raise RegistrationError(msg)
-
-        self.models[value] = cls
+        self._do_register(value, cls)
 
     def _register_plain(self, cls: type[pydantic.BaseModel]) -> None:
         """Register the model keyed by its class name.
@@ -416,11 +419,25 @@ class TrackingGroup(pydantic.BaseModel):
         cls
             The model to register.
         """
-        key = str(id(cls))
-        if (other := self.models.get(key)) is not None and other is not cls:
-            msg = (
-                f'Cannot register {cls.__name__} under the "{key}" '
-                f"identifier, which is already in use by {other.__name__}."
-            )
-            raise RegistrationError(msg)
-        self.models[key] = cls
+        self._do_register(str(id(cls)), cls)
+
+    def _do_register(self, key: str, cls: type[pydantic.BaseModel]) -> None:
+        """Register the given model under the given key
+
+        Parameters
+        ----------
+        key
+            The key under which to register the model
+        cls
+            The model to register.
+        """
+        if (other := self.models.get(key)) is not None:
+            if other is not cls:
+                msg = (
+                    f'Cannot register {cls.__name__} under the "{key}" '
+                    f"identifier, which is already in use by {other.__name__}."
+                )
+                raise RegistrationError(msg)
+        else:
+            self._generation += 1
+            self.models[key] = cls

--- a/src/dynapydantic/tracking_group.py
+++ b/src/dynapydantic/tracking_group.py
@@ -392,8 +392,7 @@ class TrackingGroup(pydantic.BaseModel):
             self._adapter_generation = self.generation
 
         # casting because the if statement ensures it is non-None (because
-        # __DYNAPYDANTIC_SCHEMA_GENERATION__ starts at -1 and generation
-        # increments from 0.
+        # _adapter_generation starts at -1 and generation increments from 0.
         return ty.cast("pydantic.TypeAdapter", self._adapter)
 
     def _register_with_discriminator_field(self, cls: type[pydantic.BaseModel]) -> None:

--- a/src/dynapydantic/tracking_group.py
+++ b/src/dynapydantic/tracking_group.py
@@ -104,14 +104,8 @@ class TrackingGroup(pydantic.BaseModel):
     )
 
     _generation: int = pydantic.PrivateAttr(default=0)
-
-    @property
-    def generation(self) -> int:
-        """The generation of the tracking group.
-
-        This is a counter that increments every time a new registration occurs
-        """
-        return self._generation
+    _adapter: pydantic.TypeAdapter | None = pydantic.PrivateAttr(default=None)
+    _adapter_generation: int = pydantic.PrivateAttr(default=-1)
 
     @pydantic.model_validator(mode="after")
     def _ensure_union_mode(self) -> "TrackingGroup":
@@ -381,6 +375,26 @@ class TrackingGroup(pydantic.BaseModel):
 
         # "smart" mode is pydantic's default behavior on a plain union
         return plain_union
+
+    @property
+    def generation(self) -> int:
+        """The generation of the tracking group.
+
+        This is a counter that increments every time a new registration occurs
+        """
+        return self._generation
+
+    @property
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        """Get the pydantic TypeAdapter for the union of all group members"""
+        if self.generation != self._adapter_generation:
+            self._adapter = pydantic.TypeAdapter(self.union())
+            self._adapter_generation = self.generation
+
+        # casting because the if statement ensures it is non-None (because
+        # __DYNAPYDANTIC_SCHEMA_GENERATION__ starts at -1 and generation
+        # increments from 0.
+        return ty.cast("pydantic.TypeAdapter", self._adapter)
 
     def _register_with_discriminator_field(self, cls: type[pydantic.BaseModel]) -> None:
         """Register the model with the default of the discriminator field

--- a/tests/test_implicit_unions.py
+++ b/tests/test_implicit_unions.py
@@ -1,13 +1,6 @@
-"""TDD tests for lazy subclass union validation (Option B).
+"""Tests for the implicit_polymorphic option on SubclassTrackingModel"""
 
-The goal is to make ``Base``-typed fields on containing models dispatch to
-registered subclasses *without* requiring ``dynapydantic.Polymorphic``.
-Validation must pick up newly registered subclasses at call time, not at
-schema-build time.
-
-These tests are written against the *desired* behaviour and will all fail
-until Option B is implemented.
-"""
+import datetime
 
 import pydantic
 import pytest
@@ -149,111 +142,7 @@ def test_generation_advances_on_each_new_registration() -> None:
 
 
 # ===========================================================================
-# 3.  Caching — the TypeAdapter is not rebuilt on every validation call
-# ===========================================================================
-
-
-def test_adapter_cached_between_calls_when_no_new_subclasses() -> None:
-    """Repeated validation reuses the cached adapter (same object identity)."""
-    base = _make_discriminated_base()
-
-    class Child(base):
-        v: int
-
-    class Container(pydantic.BaseModel):
-        item: base
-
-    Container.model_validate({"item": {"kind": "Child", "v": 1}})
-    adapter_after_first = base.__DYNAPYDANTIC_ADAPTER__
-
-    Container.model_validate({"item": {"kind": "Child", "v": 2}})
-    adapter_after_second = base.__DYNAPYDANTIC_ADAPTER__
-
-    assert adapter_after_first is adapter_after_second
-
-
-def test_adapter_replaced_after_new_subclass_registered() -> None:
-    """Adding a subclass causes the adapter to be rebuilt on next validation."""
-    base = _make_discriminated_base()
-
-    class EarlyChild(base):
-        v: int
-
-    class Container(pydantic.BaseModel):
-        item: base
-
-    Container.model_validate({"item": {"kind": "EarlyChild", "v": 0}})
-    adapter_before = base.__DYNAPYDANTIC_ADAPTER__
-
-    class LateChild(base):
-        w: str
-
-    Container.model_validate({"item": {"kind": "LateChild", "w": "hi"}})
-    adapter_after = base.__DYNAPYDANTIC_ADAPTER__
-
-    assert adapter_before is not adapter_after
-
-
-# ===========================================================================
-# 4.  Generation tracking attribute exists and is initialised
-# ===========================================================================
-
-
-def test_schema_generation_sentinel_before_first_validation() -> None:
-    """Before any validation the stored generation is a sentinel < 0."""
-    base = _make_discriminated_base()
-
-    class Child(base):
-        x: int
-
-    # __DYNAPYDANTIC_SCHEMA_GENERATION__ should be set to some sentinel
-    # (e.g. -1) indicating "not yet built".
-    gen = base.__DYNAPYDANTIC_SCHEMA_GENERATION__
-    assert gen < 0
-
-
-def test_schema_generation_synced_after_first_validation() -> None:
-    """After the first validation the cached generation matches the group."""
-    base = _make_discriminated_base()
-
-    class Child(base):
-        x: int
-
-    class Container(pydantic.BaseModel):
-        item: base
-
-    Container.model_validate({"item": {"kind": "Child", "x": 5}})
-
-    assert base.__DYNAPYDANTIC__.generation == base.__DYNAPYDANTIC_SCHEMA_GENERATION__
-
-
-def test_adapter_attribute_is_none_first_validation() -> None:
-    """``__DYNAPYDANTIC_ADAPTER__`` is None before first validation"""
-    base = _make_discriminated_base()
-
-    class Child(base):
-        x: int
-
-    assert getattr(base, "__DYNAPYDANTIC_ADAPTER__", object()) is None
-
-
-def test_adapter_attribute_present_after_first_validation() -> None:
-    """``__DYNAPYDANTIC_ADAPTER__`` is created on the first validation."""
-    base = _make_discriminated_base()
-
-    class Child(base):
-        x: int
-
-    class Container(pydantic.BaseModel):
-        item: base
-
-    Container.model_validate({"item": {"kind": "Child", "x": 1}})
-    assert hasattr(base, "__DYNAPYDANTIC_ADAPTER__")
-    assert isinstance(base.__DYNAPYDANTIC_ADAPTER__, pydantic.TypeAdapter)
-
-
-# ===========================================================================
-# 5.  Serialisation round-trip
+# 3.  Serialisation round-trip
 # ===========================================================================
 
 
@@ -261,15 +150,20 @@ def test_model_dump_preserves_subclass_fields() -> None:
     """``model_dump()`` on the container exposes subclass-specific fields."""
     base = _make_discriminated_base()
 
+    dt_str = "2026-04-16T21:42:00Z"
+    dt = datetime.datetime.fromisoformat(dt_str)
+
     class Child(base):
-        payload: str
+        payload: datetime.datetime
 
     class Container(pydantic.BaseModel):
         item: base
 
-    obj = Container.model_validate({"item": {"kind": "Child", "payload": "data"}})
+    obj = Container(item={"kind": "Child", "payload": dt})
     dumped = obj.model_dump()
-    assert dumped == {"item": {"kind": "Child", "payload": "data"}}
+    assert dumped == {"item": {"kind": "Child", "payload": dt}}
+    dumped_json = obj.model_dump(mode="json")
+    assert dumped_json == {"item": {"kind": "Child", "payload": dt_str}}
 
 
 def test_round_trip_json() -> None:
@@ -307,7 +201,7 @@ def test_round_trip_already_instantiated_object() -> None:
 
 
 # ===========================================================================
-# 6.  Backward-compat: Polymorphic still works unchanged
+# 4.  Backward-compat: Polymorphic still works unchanged
 # ===========================================================================
 
 
@@ -342,7 +236,7 @@ def test_polymorphic_picks_up_late_subclass() -> None:
 
 
 # ===========================================================================
-# 7.  Edge cases
+# 5.  Edge cases
 # ===========================================================================
 
 
@@ -371,10 +265,10 @@ def test_multiple_containers_share_same_adapter_cache() -> None:
         item: base
 
     ContainerA.model_validate({"item": {"kind": "Child", "n": 1}})
-    adapter_a = base.__DYNAPYDANTIC_ADAPTER__  # type: ignore[attr-defined]
+    adapter_a = base.__DYNAPYDANTIC__.type_adapter
 
     ContainerB.model_validate({"item": {"kind": "Child", "n": 2}})
-    adapter_b = base.__DYNAPYDANTIC_ADAPTER__  # type: ignore[attr-defined]
+    adapter_b = base.__DYNAPYDANTIC__.type_adapter
 
     # Both containers use the same cached TypeAdapter on the base class
     assert adapter_a is adapter_b
@@ -446,7 +340,7 @@ def test_json_schema_works_on_simple_smart_union() -> None:
 
 
 # ===========================================================================
-# 8.  Error Behavior
+# 6.  Error Behavior
 # ===========================================================================
 
 

--- a/tests/test_implicit_unions.py
+++ b/tests/test_implicit_unions.py
@@ -387,3 +387,61 @@ def test_validation_error_good_message_on_disc_union() -> None:
         pydantic.ValidationError, match=r"(?s)item\.Child1\.a.*required"
     ):
         Container(item={"kind": "Child1"})
+
+
+def test_implicit_recursive_models() -> None:
+    """Tests recursive models with an implicit union"""
+
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        discriminator_field="name",
+        discriminator_value_generator=lambda cls: cls.__name__,
+        implicit_polymorphic=True,
+    ):
+        """Base class, has discriminator value generator"""
+
+    class Base2(
+        dynapydantic.SubclassTrackingModel,
+        discriminator_field="name",
+        discriminator_value_generator=lambda cls: cls.__name__,
+        implicit_polymorphic=True,
+    ):
+        """Base class, has discriminator value generator"""
+
+    class A(Base):
+        """A concrete non-recursive subclass"""
+
+        a: int
+
+    class B(Base):
+        """A concrete recursive subclass"""
+
+        b: int
+        other: Base
+
+    class C(Base):
+        """Recursive subclass"""
+
+        c: Base
+        other: Base2
+
+    class D(Base2):
+        d: int
+        other: Base
+
+    model = D.model_validate_json(
+        """
+        {
+          "name": "D", "d": 1, "other": {
+            "name": "B", "b": 2, "other": {
+              "name": "C", "c": {"name": "A", "a": 3}, "other": {
+                "name": "D", "d": 4, "other": {
+                  "name": "A", "a": 5
+                }
+              }
+            }
+          }
+        }
+        """
+    )
+    assert model == D(d=1, other=B(b=2, other=C(c=A(a=3), other=D(d=4, other=A(a=5)))))

--- a/tests/test_implicit_unions.py
+++ b/tests/test_implicit_unions.py
@@ -150,7 +150,7 @@ def test_model_dump_preserves_subclass_fields() -> None:
     """``model_dump()`` on the container exposes subclass-specific fields."""
     base = _make_discriminated_base()
 
-    dt_str = "2026-04-16T21:42:00+00:00"
+    dt_str = "2026-04-16T21:42:00+01:00"
     dt = datetime.datetime.fromisoformat(dt_str)
 
     class Child(base):

--- a/tests/test_implicit_unions.py
+++ b/tests/test_implicit_unions.py
@@ -150,7 +150,7 @@ def test_model_dump_preserves_subclass_fields() -> None:
     """``model_dump()`` on the container exposes subclass-specific fields."""
     base = _make_discriminated_base()
 
-    dt_str = "2026-04-16T21:42:00Z"
+    dt_str = "2026-04-16T21:42:00+00:00"
     dt = datetime.datetime.fromisoformat(dt_str)
 
     class Child(base):

--- a/tests/test_implicit_unions.py
+++ b/tests/test_implicit_unions.py
@@ -1,0 +1,495 @@
+"""TDD tests for lazy subclass union validation (Option B).
+
+The goal is to make ``Base``-typed fields on containing models dispatch to
+registered subclasses *without* requiring ``dynapydantic.Polymorphic``.
+Validation must pick up newly registered subclasses at call time, not at
+schema-build time.
+
+These tests are written against the *desired* behaviour and will all fail
+until Option B is implemented.
+"""
+
+import pydantic
+import pytest
+
+import dynapydantic
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_discriminated_base() -> type[dynapydantic.SubclassTrackingModel]:
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        discriminator_field="kind",
+        discriminator_value_generator=lambda cls: cls.__name__,
+        implicit_polymorphic=True,
+    ):
+        """Base class for a discriminated union"""
+
+    return Base
+
+
+def _make_smart_base() -> type[dynapydantic.SubclassTrackingModel]:
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        union_mode="smart",
+        implicit_polymorphic=True,
+    ):
+        """Base class for a discriminated union"""
+
+    return Base
+
+
+# ===========================================================================
+# 1.  Direct field annotation (no Polymorphic) — the core ergonomics test
+# ===========================================================================
+
+
+def test_discriminated_subclass_resolved_via_base_annotation() -> None:
+    """Fields typed as the base class validate to the correct subclass."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        value: int
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    result = Container.model_validate({"item": {"kind": "Child", "value": 7}})
+    assert isinstance(result.item, Child)
+    assert result.item.value == 7
+
+
+def test_smart_union_subclass_resolved_via_base_annotation() -> None:
+    """Smart-mode base field resolves the correct subclass without discriminator."""
+    base = _make_smart_base()
+
+    class OnlyInt(base):
+        x: int
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    result = Container.model_validate({"item": {"x": 3}})
+    assert isinstance(result.item, OnlyInt)
+    assert result.item.x == 3
+
+
+def test_invalid_data_raises_validation_error() -> None:
+    """Invalid data still raises ``pydantic.ValidationError``."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        value: int
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    with pytest.raises(pydantic.ValidationError):
+        Container.model_validate({"item": {"kind": "NonExistent", "value": 1}})
+
+
+# ===========================================================================
+# 2.  Lazy registration — subclass added *after* the containing model is built
+# ===========================================================================
+
+
+def test_late_subclass_is_picked_up_without_model_rebuild() -> None:
+    """A subclass defined after the container validates on the next call."""
+    base = _make_discriminated_base()
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    # Container is fully compiled *before* LateChild exists.
+    class LateChild(base):
+        score: float
+
+    result = Container.model_validate({"item": {"kind": "LateChild", "score": 9.5}})
+    assert isinstance(result.item, LateChild)
+    assert result.item.score == pytest.approx(9.5)
+
+
+def test_multiple_late_subclasses_all_visible() -> None:
+    """Several subclasses added after container build are each reachable."""
+    base = _make_discriminated_base()
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    class Alpha(base):
+        a: str
+
+    class Beta(base):
+        b: str
+
+    alpha = Container.model_validate({"item": {"kind": "Alpha", "a": "hello"}})
+    beta = Container.model_validate({"item": {"kind": "Beta", "b": "world"}})
+
+    assert isinstance(alpha.item, Alpha)
+    assert isinstance(beta.item, Beta)
+
+
+def test_generation_advances_on_each_new_registration() -> None:
+    """``TrackingGroup._generation`` increments for every new subclass."""
+    base = _make_discriminated_base()
+    initial = base.__DYNAPYDANTIC__._generation  # noqa: SLF001
+
+    class C1(base):
+        x: int
+
+    assert base.__DYNAPYDANTIC__.generation == initial + 1
+
+    class C2(base):
+        y: int
+
+    assert base.__DYNAPYDANTIC__.generation == initial + 2
+
+
+# ===========================================================================
+# 3.  Caching — the TypeAdapter is not rebuilt on every validation call
+# ===========================================================================
+
+
+def test_adapter_cached_between_calls_when_no_new_subclasses() -> None:
+    """Repeated validation reuses the cached adapter (same object identity)."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        v: int
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    Container.model_validate({"item": {"kind": "Child", "v": 1}})
+    adapter_after_first = base.__DYNAPYDANTIC_ADAPTER__
+
+    Container.model_validate({"item": {"kind": "Child", "v": 2}})
+    adapter_after_second = base.__DYNAPYDANTIC_ADAPTER__
+
+    assert adapter_after_first is adapter_after_second
+
+
+def test_adapter_replaced_after_new_subclass_registered() -> None:
+    """Adding a subclass causes the adapter to be rebuilt on next validation."""
+    base = _make_discriminated_base()
+
+    class EarlyChild(base):
+        v: int
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    Container.model_validate({"item": {"kind": "EarlyChild", "v": 0}})
+    adapter_before = base.__DYNAPYDANTIC_ADAPTER__
+
+    class LateChild(base):
+        w: str
+
+    Container.model_validate({"item": {"kind": "LateChild", "w": "hi"}})
+    adapter_after = base.__DYNAPYDANTIC_ADAPTER__
+
+    assert adapter_before is not adapter_after
+
+
+# ===========================================================================
+# 4.  Generation tracking attribute exists and is initialised
+# ===========================================================================
+
+
+def test_schema_generation_sentinel_before_first_validation() -> None:
+    """Before any validation the stored generation is a sentinel < 0."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        x: int
+
+    # __DYNAPYDANTIC_SCHEMA_GENERATION__ should be set to some sentinel
+    # (e.g. -1) indicating "not yet built".
+    gen = base.__DYNAPYDANTIC_SCHEMA_GENERATION__
+    assert gen < 0
+
+
+def test_schema_generation_synced_after_first_validation() -> None:
+    """After the first validation the cached generation matches the group."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        x: int
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    Container.model_validate({"item": {"kind": "Child", "x": 5}})
+
+    assert base.__DYNAPYDANTIC__.generation == base.__DYNAPYDANTIC_SCHEMA_GENERATION__
+
+
+def test_adapter_attribute_is_none_first_validation() -> None:
+    """``__DYNAPYDANTIC_ADAPTER__`` is None before first validation"""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        x: int
+
+    assert getattr(base, "__DYNAPYDANTIC_ADAPTER__", object()) is None
+
+
+def test_adapter_attribute_present_after_first_validation() -> None:
+    """``__DYNAPYDANTIC_ADAPTER__`` is created on the first validation."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        x: int
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    Container.model_validate({"item": {"kind": "Child", "x": 1}})
+    assert hasattr(base, "__DYNAPYDANTIC_ADAPTER__")
+    assert isinstance(base.__DYNAPYDANTIC_ADAPTER__, pydantic.TypeAdapter)
+
+
+# ===========================================================================
+# 5.  Serialisation round-trip
+# ===========================================================================
+
+
+def test_model_dump_preserves_subclass_fields() -> None:
+    """``model_dump()`` on the container exposes subclass-specific fields."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        payload: str
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    obj = Container.model_validate({"item": {"kind": "Child", "payload": "data"}})
+    dumped = obj.model_dump()
+    assert dumped == {"item": {"kind": "Child", "payload": "data"}}
+
+
+def test_round_trip_json() -> None:
+    """JSON serialisation + deserialisation preserves type and values."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        number: int
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    original = Container.model_validate({"item": {"kind": "Child", "number": 42}})
+    json_str = original.model_dump_json()
+    restored = Container.model_validate_json(json_str)
+
+    assert isinstance(restored.item, Child)
+    assert restored.item.number == 42
+
+
+def test_round_trip_already_instantiated_object() -> None:
+    """Passing an already-constructed subclass instance into model_validate works."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        tag: str
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    child_obj = Child(tag="hello")
+    container = Container(item=child_obj)
+    assert isinstance(container.item, Child)
+    assert container.item.tag == "hello"
+
+
+# ===========================================================================
+# 6.  Backward-compat: Polymorphic still works unchanged
+# ===========================================================================
+
+
+def test_polymorphic_annotation_resolves_subclass() -> None:
+    """Explicit Polymorphic annotation resolves subclass correctly."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        v: int
+
+    class Container(pydantic.BaseModel):
+        item: dynapydantic.Polymorphic[base]
+
+    result = Container.model_validate({"item": {"kind": "Child", "v": 99}})
+    assert isinstance(result.item, Child)
+    assert result.item.v == 99
+
+
+def test_polymorphic_picks_up_late_subclass() -> None:
+    """With Polymorphic, late-registered subclass is also picked up lazily."""
+    base = _make_discriminated_base()
+
+    class Container(pydantic.BaseModel):
+        item: dynapydantic.Polymorphic[base]
+
+    class LateChild(base):
+        z: bool
+
+    result = Container.model_validate({"item": {"kind": "LateChild", "z": True}})
+    assert isinstance(result.item, LateChild)
+    assert result.item.z is True
+
+
+# ===========================================================================
+# 7.  Edge cases
+# ===========================================================================
+
+
+def test_base_with_no_subclasses_raises_on_validate() -> None:
+    """Validating when no subclasses are registered raises ValidationError."""
+    base = _make_discriminated_base()
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    with pytest.raises(pydantic.ValidationError):
+        Container.model_validate({"item": {"kind": "Ghost", "x": 1}})
+
+
+def test_multiple_containers_share_same_adapter_cache() -> None:
+    """Two unrelated containers referencing the same base share the adapter."""
+    base = _make_discriminated_base()
+
+    class Child(base):
+        n: int
+
+    class ContainerA(pydantic.BaseModel):
+        item: base
+
+    class ContainerB(pydantic.BaseModel):
+        item: base
+
+    ContainerA.model_validate({"item": {"kind": "Child", "n": 1}})
+    adapter_a = base.__DYNAPYDANTIC_ADAPTER__  # type: ignore[attr-defined]
+
+    ContainerB.model_validate({"item": {"kind": "Child", "n": 2}})
+    adapter_b = base.__DYNAPYDANTIC_ADAPTER__  # type: ignore[attr-defined]
+
+    # Both containers use the same cached TypeAdapter on the base class
+    assert adapter_a is adapter_b
+
+
+def test_exclude_from_union_still_excluded() -> None:
+    """``exclude_from_union=True`` subclasses are never dispatched to."""
+    base = _make_discriminated_base()
+
+    class Excluded(base, exclude_from_union=True):
+        secret: str
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    with pytest.raises(pydantic.ValidationError):
+        Container.model_validate({"item": {"kind": "Excluded", "secret": "shh"}})
+
+
+@pytest.mark.parametrize(
+    "union_mode",
+    [
+        pytest.param("smart", id="smart"),
+        pytest.param("left_to_right", id="left-to-right"),
+    ],
+)
+def test_non_discriminated_modes_also_lazy(union_mode: str) -> None:
+    """Smart and left_to_right union modes are also lazily rebuilt."""
+
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        union_mode=union_mode,
+        implicit_polymorphic=True,
+    ):
+        pass
+
+    class Container(pydantic.BaseModel):
+        item: Base
+
+    class OnlyChild(Base):
+        q: int
+
+    result = Container.model_validate({"item": {"q": 11}})
+    assert isinstance(result.item, OnlyChild)
+    assert result.item.q == 11
+
+
+def test_json_schema_works_on_simple_smart_union() -> None:
+    """JSON schema works on a simple two-member smart union"""
+    base = _make_smart_base()
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    class Child1(base, extra="forbid"):
+        a: int
+
+    class Child2(base, extra="forbid"):
+        b: int
+
+    js = Container.model_json_schema()
+    assert js["properties"]["item"] == {
+        "anyOf": [
+            {"$ref": "#/$defs/Child1"},
+            {"$ref": "#/$defs/Child2"},
+        ],
+        "title": "Item",
+    }
+
+
+# ===========================================================================
+# 8.  Error Behavior
+# ===========================================================================
+
+
+def test_validation_error_good_message_on_smart_union() -> None:
+    """The validation error should still be good (smart union)"""
+    base = _make_smart_base()
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    class Child1(base, extra="forbid"):
+        a: int
+
+    class Child2(base, extra="forbid"):
+        b: int
+
+    with pytest.raises(
+        pydantic.ValidationError,
+        match=r"(?s)item\.Child1\.a.*required.*item\.Child2.b.*required",
+    ):
+        Container(item={"c": 1})
+
+
+def test_validation_error_good_message_on_disc_union() -> None:
+    """The validation error should still be good (discriminated union)"""
+    base = _make_discriminated_base()
+
+    class Container(pydantic.BaseModel):
+        item: base
+
+    class Child1(base, extra="forbid"):
+        a: int
+
+    class Child2(base, extra="forbid"):
+        b: int
+
+    with pytest.raises(
+        pydantic.ValidationError,
+        match=r"(?s)item.*Unable to extract tag using discriminator",
+    ):
+        Container(item={"c": 1})
+
+    with pytest.raises(
+        pydantic.ValidationError, match=r"(?s)item\.Child1\.a.*required"
+    ):
+        Container(item={"kind": "Child1"})

--- a/tests/test_tracking_group.py
+++ b/tests/test_tracking_group.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pydantic
 import pytest
+from pydantic_core._pydantic_core import ValidationError
 
 import dynapydantic
 
@@ -595,3 +596,43 @@ def test_field_clobbering_not_allowed() -> None:
         ),
     ):
         group.register_model(C)
+
+
+def test_type_adapter() -> None:
+    """Test functionality of the type adapter"""
+    group = dynapydantic.TrackingGroup(
+        name="Test",
+        discriminator_field="name",
+        discriminator_value_generator=lambda cls: cls.__name__,
+    )
+
+    with pytest.raises(dynapydantic.NoRegisteredTypesError):
+        group.type_adapter  # noqa: B018
+
+    @group.register
+    class A(pydantic.BaseModel):
+        a: int
+
+    # Should be able to be computed after a class is registered. Should not
+    # recompute.
+    ta1 = group.type_adapter
+    assert isinstance(ta1, pydantic.TypeAdapter)
+    ta2 = group.type_adapter
+    assert ta1 is ta2
+
+    assert ta1.validate_python({"name": "A", "a": 1}) == A(a=1)
+
+    @group.register
+    class B(pydantic.BaseModel):
+        b: int
+
+    ta3 = group.type_adapter
+    assert isinstance(ta3, pydantic.TypeAdapter)
+    assert ta3 is not ta1
+    ta4 = group.type_adapter
+    assert ta3 is ta4
+
+    assert ta3.validate_python({"name": "A", "a": 1}) == A(a=1)
+    assert ta3.validate_python({"name": "B", "b": 3}) == B(b=3)
+    with pytest.raises(ValidationError, match=r"(?s)A\.a.*required"):
+        ta3.validate_python({"name": "A"})

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ wheels = [
 
 [[package]]
 name = "dynapydantic"
-version = "0.3.0"
+version = "0.4.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This PR adds a `implicit_polymorphic` option to `SubclassTrackingModel`. Specifying this option means that `dynapydantic.Polymorphic` is no longer required, simply giving the base class as a field annotation will validate polymorphically.

The main drawback of this approach is that we are punting the cost of schema compilation until validation time and thus there may be performance hits at validation time.

While this approach does remove the need for explicit model rebuilds on recursive models, validation and JSON schemas are still sensitive to the location at which they are called. They can't "see into the future", they will reflect the subclasses that have been registered at the time at which they are called.

Example:
```python
class Base(
    dynapydantic.SubclassTrackingModel,
    discriminator_field="name",
    discriminator_value_generator=lambda cls: cls.__name__,
    implicit_polymorphic=True,
):
    pass

class Base2(
    dynapydantic.SubclassTrackingModel,
    discriminator_field="name",
    discriminator_value_generator=lambda cls: cls.__name__,
    implicit_polymorphic=True,
):  
    pass
        
class A(Base):
    a: int

class B(Base):
    b: int
    other: Base
        
class C(Base):
    c: Base
    other: Base2

class D(Base2):
    d: int
    other: Base

model = D.model_validate_json(
    """
    {
      "name": "D", "d": 1, "other": {
        "name": "B", "b": 2, "other": {
          "name": "C", "c": {"name": "A", "a": 3}, "other": {
            "name": "D", "d": 4, "other": {
              "name": "A", "a": 5
            }
          }
        }
      }
    }
    """
)

assert model == D(d=1, other=B(b=2, other=C(c=A(a=3), other=D(d=4, other=A(a=5)))))
```