### PR TITLE
Added support for Generic SubclassTrackingModel's

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ convention = "numpy"
     "PLC0415", # imports in CLI functions improve load times
 ]
 
+[tool.ruff.per-file-target-version]
+"tests/test_generics_py312.py" = "py312"
+
 [tool.pyrefly]
 # We have a few embedded packages in our tests to test out plugins
 search-path = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dynapydantic"
-version = "0.5.2a1"
+version = "0.6.0"
 description = "Dyanmic pydantic models"
 readme = "README.md"
 authors = [

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -186,7 +186,9 @@ def _exclude_from_union_default(model_t: type[SubclassTrackingModel]) -> bool:
         return True
 
     # 3. We are a concrete generic class and our origin is a direct
-    #    descendent of SubclassTrackingModel. Combined cas of 1 and 2.
+    #    descendent of SubclassTrackingModel. Combined case of 1 and 2. A
+    #    concrete generic that is not a direct descendent is the same as any
+    #    other class in the middle of an inheritance tree.
     generic_origin = model_t.__pydantic_generic_metadata__["origin"]
     if generic_origin is None:
         return False
@@ -194,7 +196,7 @@ def _exclude_from_union_default(model_t: type[SubclassTrackingModel]) -> bool:
 
 
 def _is_uninstantiated_generic(model_t: type[SubclassTrackingModel]) -> bool:
-    """Determine if this an a generic model with uninstantiated args"""
+    """Determine if this a generic model with uninstantiated args"""
     generic_args = model_t.__pydantic_generic_metadata__["parameters"]
     return any(isinstance(arg, ty.TypeVar) for arg in generic_args)
 

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -79,12 +79,13 @@ class SubclassTrackingModel(pydantic.BaseModel):
         )
 
         # If we are going to be tracked, walk the entire MRO (to support
-        # multi-level tree) and register ourselves with each oe.
+        # multi-level tree) and register ourselves with each one.
         if not cls.__DYNAPYDANTIC_STM_CONFIG__.exclude_from_union:
             for base in cls.__mro__:
                 if (
                     issubclass(base, SubclassTrackingModel)
                     and base is not SubclassTrackingModel
+                    and not _is_uninstantiated_generic(base)
                 ):
                     base.__DYNAPYDANTIC__.register_model(cls)
 
@@ -163,17 +164,39 @@ class _StmConfig:
                 msg = f"invalid union_realization: {e}"
                 raise ConfigurationError(msg) from e
 
-        # Figure out if model_t is are excluded from tracking unions. Prefer
-        # direct argument, default to True if we are direct descendent of
-        # SubclassTrackingModel and False otherwise. This is because direct
-        # descendents tend to be the abstract base classes.
         if exclude_from_union is None:
-            exclude_from_union = SubclassTrackingModel in model_t.__bases__
+            exclude_from_union = _exclude_from_union_default(model_t)
 
         return cls(
             union_realization=union_realization,
             exclude_from_union=exclude_from_union,
         )
+
+
+def _exclude_from_union_default(model_t: type[SubclassTrackingModel]) -> bool:
+    """Determine the default value for exclude_from_union"""
+    # In general, this shall default to False. It will default to True if:
+    # 1. We are direct descendent of SubclassTrackingModel. This is
+    #    because direct descendents tend to be the abstract base classes.
+    if SubclassTrackingModel in model_t.__bases__:
+        return True
+
+    # 2. We are a generic class with a TypeVar argument (non-concrete).
+    if _is_uninstantiated_generic(model_t):
+        return True
+
+    # 3. We are a concrete generic class and our origin is a direct
+    #    descendent of SubclassTrackingModel. Combined cas of 1 and 2.
+    generic_origin = model_t.__pydantic_generic_metadata__["origin"]
+    if generic_origin is None:
+        return False
+    return SubclassTrackingModel in generic_origin.__bases__
+
+
+def _is_uninstantiated_generic(model_t: type[SubclassTrackingModel]) -> bool:
+    """Determine if this an a generic model with uninstantiated args"""
+    generic_args = model_t.__pydantic_generic_metadata__["parameters"]
+    return any(isinstance(arg, ty.TypeVar) for arg in generic_args)
 
 
 _UNSET = object()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest configuration"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool:
+    """Determine whether to ignore a certain path"""
+    del config
+
+    match = re.search(r"test_.*_py3(?P<minor>[0-9]+)\.py", collection_path.name)
+    if match is not None and sys.version_info < (3, int(match.group("minor"))):
+        return True
+    return False

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -7,6 +7,7 @@ import pydantic
 import dynapydantic
 
 T = ty.TypeVar("T")
+T2 = ty.TypeVar("T2")
 
 
 def test_generic_subclass_tracking_model_basic() -> None:
@@ -96,10 +97,10 @@ def test_multilayer_generic() -> None:
     class ConcreteInt(Base[int]):
         """A concrete subclass of Base[int]"""
 
-    class GenericMid(ConcreteInt, ty.Generic[T]):
+    class GenericMid(ConcreteInt, ty.Generic[T2]):
         """An intermediate generic base"""
 
-        f2: T
+        f2: T2
 
     class ConcreteInt2(GenericMid[int]):
         """A concrete subclass of GenericMid[int]"""

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,0 +1,127 @@
+"""Unit tests for the generics"""
+
+import typing as ty
+
+import pydantic
+
+import dynapydantic
+
+T = ty.TypeVar("T")
+
+
+def test_generic_subclass_tracking_model_basic() -> None:
+    """Test that a generic SubclassTrackingModel passes a basic smoke test"""
+
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        ty.Generic[T],
+        discriminator_field="kind",
+    ):
+        """Generic subclass of SubclassTrackingModel"""
+
+        f: T
+
+    class Model(pydantic.BaseModel):
+        a: int
+
+    class Concrete(Base[Model]):
+        """A concrete subclass of Base[Model]"""
+
+        kind: ty.Literal["concrete"] = "concrete"
+
+    assert dynapydantic.registered_models(Base[Model]) == {"concrete": Concrete}
+    assert dynapydantic.registered_models(Base) == {}
+
+
+def test_generic_subclass_tracking_model_basic_value_gen() -> None:
+    """Test that a generic SubclassTrackingModel passes a basic smoke test"""
+
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        ty.Generic[T],
+        discriminator_field="kind",
+        discriminator_value_generator=lambda x: x.__name__,
+    ):
+        """Generic subclass of SubclassTrackingModel"""
+
+        f: T
+
+    class Model(pydantic.BaseModel):
+        a: int
+
+    class Concrete(Base[Model]):
+        """A concrete subclass of Base[Model]"""
+
+    assert dynapydantic.registered_models(Base[Model]) == {"Concrete": Concrete}
+    assert dynapydantic.registered_models(Base) == {}
+
+
+def test_that_generic_subclass_tracking_models_isolate() -> None:
+    """Test that generic SubclassTrackingModels isolate registered models"""
+
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        ty.Generic[T],
+        discriminator_field="kind",
+        discriminator_value_generator=lambda x: x.__name__,
+    ):
+        """Generic subclass of SubclassTrackingModel"""
+
+        f: T
+
+    class ConcreteInt(Base[int]):
+        """A concrete subclass of Base[int]"""
+
+    class ConcreteStr(Base[str]):
+        """A concrete subclass of Base[str]"""
+
+    assert dynapydantic.registered_models(Base[int]) == {"ConcreteInt": ConcreteInt}
+    assert dynapydantic.registered_models(Base[str]) == {"ConcreteStr": ConcreteStr}
+    assert dynapydantic.registered_models(Base) == {}
+
+
+def test_multilayer_generic() -> None:
+    """Test the behavior of multiple generics in an inheritance tree"""
+
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        ty.Generic[T],
+        discriminator_field="kind",
+        discriminator_value_generator=lambda x: x.__name__,
+    ):
+        """Generic subclass of SubclassTrackingModel"""
+
+        f: T
+
+    class ConcreteInt(Base[int]):
+        """A concrete subclass of Base[int]"""
+
+    class GenericMid(ConcreteInt, ty.Generic[T]):
+        """An intermediate generic base"""
+
+        f2: T
+
+    class ConcreteInt2(GenericMid[int]):
+        """A concrete subclass of GenericMid[int]"""
+
+    class ConcreteStr(GenericMid[str]):
+        """A concrete subclass of GenericMid[str]"""
+
+    assert dynapydantic.registered_models(Base[int]) == {
+        "ConcreteInt": ConcreteInt,
+        "GenericMid[int]": GenericMid[int],
+        "GenericMid[str]": GenericMid[str],
+        "ConcreteInt2": ConcreteInt2,
+        "ConcreteStr": ConcreteStr,
+    }
+    assert dynapydantic.registered_models(Base[str]) == {}
+    assert dynapydantic.registered_models(GenericMid) == {}
+    assert dynapydantic.registered_models(GenericMid[int]) == {
+        "GenericMid[int]": GenericMid[int],
+        "ConcreteInt2": ConcreteInt2,
+    }
+    assert dynapydantic.registered_models(GenericMid[str]) == {
+        "GenericMid[str]": GenericMid[str],
+        "ConcreteStr": ConcreteStr,
+    }
+    assert dynapydantic.registered_models(Base) == {}

--- a/tests/test_generics_py312.py
+++ b/tests/test_generics_py312.py
@@ -1,0 +1,34 @@
+"""Unit tests for the generics"""
+
+import sys
+import typing as ty
+
+import pytest
+
+import dynapydantic
+
+T = ty.TypeVar("T")
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 11), reason="Requires Python > 3.12")
+def test_that_generic_subclass_tracking_models_isolate_py312() -> None:
+    """Test that generic SubclassTrackingModels isolate registered models"""
+
+    class Base[T2](
+        dynapydantic.SubclassTrackingModel,
+        discriminator_field="kind",
+        discriminator_value_generator=lambda x: x.__name__,
+    ):
+        """Generic subclass of SubclassTrackingModel"""
+
+        f: T2
+
+    class ConcreteInt(Base[int]):
+        """A concrete subclass of Base[int]"""
+
+    class ConcreteStr(Base[str]):
+        """A concrete subclass of Base[str]"""
+
+    assert dynapydantic.registered_models(Base[int]) == {"ConcreteInt": ConcreteInt}
+    assert dynapydantic.registered_models(Base[str]) == {"ConcreteStr": ConcreteStr}
+    assert dynapydantic.registered_models(Base) == {}

--- a/tests/test_generics_py312.py
+++ b/tests/test_generics_py312.py
@@ -1,16 +1,8 @@
 """Unit tests for the generics"""
 
-import sys
-import typing as ty
-
-import pytest
-
 import dynapydantic
 
-T = ty.TypeVar("T")
 
-
-@pytest.mark.skipif(sys.version_info <= (3, 11), reason="Requires Python > 3.12")
 def test_that_generic_subclass_tracking_models_isolate_py312() -> None:
     """Test that generic SubclassTrackingModels isolate registered models"""
 

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "dynapydantic"
-version = "0.5.2a1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -407,7 +407,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
This PR adds support for `typing.Generic` subclasses of `SubclassTrackingModel`. It essentially follows the rule that a non-concrete generic model shall not, by default, participate in `dynapydantic` tracking.

Fixes #30.