### PR TITLE
Update pydantic pin to >=2.8,<3, added a nox testing matrix to support this

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,13 @@ jobs:
         run: uv sync --locked --all-extras --dev
       - name: Run tests
         run: uv run nox -s ${{ matrix.session }}
+      - name: Prepare coverage data
+        run: mv .coverage .coverage.${{ matrix.python-version }}-${{ matrix.pydantic-version }}
       - name: Upload coverage data
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-${{ matrix.python-version }}-${{ matrix.pydantic-version }}
-          path: .coverage
+          path: .coverage.*
           include-hidden-files: true
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,20 +13,75 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          # Pydantic 2.8 added Python 3.13 support; 2.12 added Python 3.14.
+          - {python-version: "3.10", pydantic-version: "2.0"}
+          - {python-version: "3.10", pydantic-version: "2.1"}
+          - {python-version: "3.10", pydantic-version: "2.2"}
+          - {python-version: "3.10", pydantic-version: "2.3"}
+          - {python-version: "3.10", pydantic-version: "2.4"}
+          - {python-version: "3.10", pydantic-version: "2.5"}
+          - {python-version: "3.10", pydantic-version: "2.6"}
+          - {python-version: "3.10", pydantic-version: "2.7"}
+          - {python-version: "3.10", pydantic-version: "2.8"}
+          - {python-version: "3.10", pydantic-version: "2.9"}
+          - {python-version: "3.10", pydantic-version: "2.10"}
+          - {python-version: "3.10", pydantic-version: "2.11"}
+          - {python-version: "3.10", pydantic-version: "2.12"}
+          - {python-version: "3.10", pydantic-version: "2.13"}
+          - {python-version: "3.11", pydantic-version: "2.0"}
+          - {python-version: "3.11", pydantic-version: "2.1"}
+          - {python-version: "3.11", pydantic-version: "2.2"}
+          - {python-version: "3.11", pydantic-version: "2.3"}
+          - {python-version: "3.11", pydantic-version: "2.4"}
+          - {python-version: "3.11", pydantic-version: "2.5"}
+          - {python-version: "3.11", pydantic-version: "2.6"}
+          - {python-version: "3.11", pydantic-version: "2.7"}
+          - {python-version: "3.11", pydantic-version: "2.8"}
+          - {python-version: "3.11", pydantic-version: "2.9"}
+          - {python-version: "3.11", pydantic-version: "2.10"}
+          - {python-version: "3.11", pydantic-version: "2.11"}
+          - {python-version: "3.11", pydantic-version: "2.12"}
+          - {python-version: "3.11", pydantic-version: "2.13"}
+          - {python-version: "3.12", pydantic-version: "2.0"}
+          - {python-version: "3.12", pydantic-version: "2.1"}
+          - {python-version: "3.12", pydantic-version: "2.2"}
+          - {python-version: "3.12", pydantic-version: "2.3"}
+          - {python-version: "3.12", pydantic-version: "2.4"}
+          - {python-version: "3.12", pydantic-version: "2.5"}
+          - {python-version: "3.12", pydantic-version: "2.6"}
+          - {python-version: "3.12", pydantic-version: "2.7"}
+          - {python-version: "3.12", pydantic-version: "2.8"}
+          - {python-version: "3.12", pydantic-version: "2.9"}
+          - {python-version: "3.12", pydantic-version: "2.10"}
+          - {python-version: "3.12", pydantic-version: "2.11"}
+          - {python-version: "3.12", pydantic-version: "2.12"}
+          - {python-version: "3.12", pydantic-version: "2.13"}
+          - {python-version: "3.13", pydantic-version: "2.8"}
+          - {python-version: "3.13", pydantic-version: "2.9"}
+          - {python-version: "3.13", pydantic-version: "2.10"}
+          - {python-version: "3.13", pydantic-version: "2.11"}
+          - {python-version: "3.13", pydantic-version: "2.12"}
+          - {python-version: "3.13", pydantic-version: "2.13"}
+          - {python-version: "3.14", pydantic-version: "2.12"}
+          - {python-version: "3.14", pydantic-version: "2.13"}
     env:
       UV_PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install the project
         run: uv sync --locked --all-extras --dev
       - name: Run tests
-        run: uv run pytest --cov-report=xml
+        run: uv run nox -s test-${{ matrix.python-version }}-${{ matrix.pydantic-version }} -- --cov-report=xml
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
-        if: matrix.python-version == '3.14'
+        if: matrix.python-version == '3.14' && matrix.pydantic-version == '2.13'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Combine coverage data
         run: |
           uv run coverage combine coverage-data/*
-          uv run coverage xml --outfile=coverage.xml
+          uv run coverage xml -o coverage.xml
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Combine coverage data
         run: |
           uv run coverage combine coverage-data/*
-          uv run coverage xml --output=coverage.xml
+          uv run coverage xml --outfile=coverage.xml
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,7 @@ jobs:
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coverage.xml
-          format: python
+          path-to-lcov: coverage.xml
 
   publish-pypi:
     name: Publish to PyPI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,63 +8,29 @@ on:
     types: [published]
 
 jobs:
+  generate-matrix:
+    name: Generate test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      sessions: ${{ steps.sessions.outputs.sessions }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+      - name: List test sessions
+        id: sessions
+        run: |
+          sessions=$(uv run nox --json --list | jq -c '{include: [.[] | select(.session | startswith("test-")) | {session: .session, "python-version": .python, "pydantic-version": (.session | split("-")[2])}]}')
+          echo "sessions=$sessions" >> "$GITHUB_OUTPUT"
+
   test:
     name: Run tests
+    needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        include:
-          # Pydantic 2.8 added Python 3.13 support; 2.12 added Python 3.14.
-          - {python-version: "3.10", pydantic-version: "2.0"}
-          - {python-version: "3.10", pydantic-version: "2.1"}
-          - {python-version: "3.10", pydantic-version: "2.2"}
-          - {python-version: "3.10", pydantic-version: "2.3"}
-          - {python-version: "3.10", pydantic-version: "2.4"}
-          - {python-version: "3.10", pydantic-version: "2.5"}
-          - {python-version: "3.10", pydantic-version: "2.6"}
-          - {python-version: "3.10", pydantic-version: "2.7"}
-          - {python-version: "3.10", pydantic-version: "2.8"}
-          - {python-version: "3.10", pydantic-version: "2.9"}
-          - {python-version: "3.10", pydantic-version: "2.10"}
-          - {python-version: "3.10", pydantic-version: "2.11"}
-          - {python-version: "3.10", pydantic-version: "2.12"}
-          - {python-version: "3.10", pydantic-version: "2.13"}
-          - {python-version: "3.11", pydantic-version: "2.0"}
-          - {python-version: "3.11", pydantic-version: "2.1"}
-          - {python-version: "3.11", pydantic-version: "2.2"}
-          - {python-version: "3.11", pydantic-version: "2.3"}
-          - {python-version: "3.11", pydantic-version: "2.4"}
-          - {python-version: "3.11", pydantic-version: "2.5"}
-          - {python-version: "3.11", pydantic-version: "2.6"}
-          - {python-version: "3.11", pydantic-version: "2.7"}
-          - {python-version: "3.11", pydantic-version: "2.8"}
-          - {python-version: "3.11", pydantic-version: "2.9"}
-          - {python-version: "3.11", pydantic-version: "2.10"}
-          - {python-version: "3.11", pydantic-version: "2.11"}
-          - {python-version: "3.11", pydantic-version: "2.12"}
-          - {python-version: "3.11", pydantic-version: "2.13"}
-          - {python-version: "3.12", pydantic-version: "2.0"}
-          - {python-version: "3.12", pydantic-version: "2.1"}
-          - {python-version: "3.12", pydantic-version: "2.2"}
-          - {python-version: "3.12", pydantic-version: "2.3"}
-          - {python-version: "3.12", pydantic-version: "2.4"}
-          - {python-version: "3.12", pydantic-version: "2.5"}
-          - {python-version: "3.12", pydantic-version: "2.6"}
-          - {python-version: "3.12", pydantic-version: "2.7"}
-          - {python-version: "3.12", pydantic-version: "2.8"}
-          - {python-version: "3.12", pydantic-version: "2.9"}
-          - {python-version: "3.12", pydantic-version: "2.10"}
-          - {python-version: "3.12", pydantic-version: "2.11"}
-          - {python-version: "3.12", pydantic-version: "2.12"}
-          - {python-version: "3.12", pydantic-version: "2.13"}
-          - {python-version: "3.13", pydantic-version: "2.8"}
-          - {python-version: "3.13", pydantic-version: "2.9"}
-          - {python-version: "3.13", pydantic-version: "2.10"}
-          - {python-version: "3.13", pydantic-version: "2.11"}
-          - {python-version: "3.13", pydantic-version: "2.12"}
-          - {python-version: "3.13", pydantic-version: "2.13"}
-          - {python-version: "3.14", pydantic-version: "2.12"}
-          - {python-version: "3.14", pydantic-version: "2.13"}
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.sessions) }}
     env:
       UV_PYTHON: ${{ matrix.python-version }}
     steps:
@@ -78,13 +44,43 @@ jobs:
       - name: Install the project
         run: uv sync --locked --all-extras --dev
       - name: Run tests
-        run: uv run nox -s test-${{ matrix.python-version }}-${{ matrix.pydantic-version }} -- --cov-report=xml
+        run: uv run nox -s ${{ matrix.session }}
+      - name: Upload coverage data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-${{ matrix.python-version }}-${{ matrix.pydantic-version }}
+          path: .coverage
+          include-hidden-files: true
+
+  coverage:
+    name: Combine and upload coverage
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.14"
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+      - name: Download coverage data
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: coverage-*
+          path: coverage-data
+      - name: Combine coverage data
+        run: |
+          uv run coverage combine coverage-data/*
+          uv run coverage xml --output=coverage.xml
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
-        if: matrix.python-version == '3.14' && matrix.pydantic-version == '2.13'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage.xml
+          file: coverage.xml
+          format: python
 
   publish-pypi:
     name: Publish to PyPI

--- a/README.md
+++ b/README.md
@@ -26,19 +26,25 @@ conda install dynapydantic
 The supported Python/Pydantic compatibility matrix is defined in `noxfile.py`:
 
 <table>
-  <caption>Supported Python and Pydantic versions</caption>
   <thead>
     <tr>
-      <th scope="col">Python version</th>
-      <th scope="col">Pydantic 2.8</th>
-      <th scope="col">Pydantic 2.9</th>
-      <th scope="col">Pydantic 2.10</th>
-      <th scope="col">Pydantic 2.11</th>
-      <th scope="col">Pydantic 2.12</th>
-      <th scope="col">Pydantic 2.13</th>
+      <th></th>
+      <th></th>
+      <th colspan="6"> Pydantic</th>
+    </tr>
+    <tr>
+      <th></th>
+      <th></th>
+      <th scope="col">2.8</th>
+      <th scope="col">2.9</th>
+      <th scope="col">2.10</th>
+      <th scope="col">2.11</th>
+      <th scope="col">2.12</th>
+      <th scope="col">2.13</th>
     </tr>
   </thead>
   <tbody>
+     <th rowspan="7">Python </th>
     <tr>
       <th scope="row">3.10</th>
       <td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ or with `conda` via the `conda-forge` channel:
 conda install dynapydantic
 ```
 
+## Testing
+
+The supported Python/Pydantic compatibility matrix is defined in `noxfile.py`.
+Run every combination locally with:
+
+```sh
+uv run nox
+```
+
+To run one combination, for example Python 3.13 with Pydantic 2.13:
+
+```sh
+uv run nox -s test-3.13-2.13
+```
+
 
 ## Motiviation
 Consider the following simple class setup:

--- a/README.md
+++ b/README.md
@@ -25,13 +25,42 @@ conda install dynapydantic
 
 The supported Python/Pydantic compatibility matrix is defined in `noxfile.py`:
 
-| Python | Pydantic 2.8 | Pydantic 2.9 | Pydantic 2.10 | Pydantic 2.11 | Pydantic 2.12 | Pydantic 2.13 |
-| ------ | :----------: | :----------: | :-----------: | :-----------: | :-----------: | :-----------: |
-| 3.10   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| 3.11   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| 3.12   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| 3.13   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| 3.14   |   |   |   |   | ✓ | ✓ |
+<table>
+  <caption>Supported Python and Pydantic versions</caption>
+  <thead>
+    <tr>
+      <th scope="col">Python version</th>
+      <th scope="col">Pydantic 2.8</th>
+      <th scope="col">Pydantic 2.9</th>
+      <th scope="col">Pydantic 2.10</th>
+      <th scope="col">Pydantic 2.11</th>
+      <th scope="col">Pydantic 2.12</th>
+      <th scope="col">Pydantic 2.13</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">3.10</th>
+      <td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row">3.11</th>
+      <td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row">3.12</th>
+      <td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row">3.13</th>
+      <td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row">3.14</th>
+      <td></td><td></td><td></td><td></td><td>✓</td><td>✓</td>
+    </tr>
+  </tbody>
+</table>
 
 Run every combination locally with:
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ uv run nox -s test-3.13-2.13
 ```
 
 
-## Motiviation
+## Motivation
 Consider the following simple class setup:
 ```python
 import pydantic

--- a/README.md
+++ b/README.md
@@ -23,7 +23,16 @@ conda install dynapydantic
 
 ## Testing
 
-The supported Python/Pydantic compatibility matrix is defined in `noxfile.py`.
+The supported Python/Pydantic compatibility matrix is defined in `noxfile.py`:
+
+| Python | Pydantic 2.8 | Pydantic 2.9 | Pydantic 2.10 | Pydantic 2.11 | Pydantic 2.12 | Pydantic 2.13 |
+| ------ | :----------: | :----------: | :-----------: | :-----------: | :-----------: | :-----------: |
+| 3.10   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 3.11   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 3.12   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 3.13   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 3.14   |   |   |   |   | ✓ | ✓ |
+
 Run every combination locally with:
 
 ```sh

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,40 @@
+"""Nox sessions for the supported Python and Pydantic versions."""
+
+from __future__ import annotations
+
+import nox
+
+PYTHON_VERSIONS = ("3.10", "3.11", "3.12", "3.13", "3.14")
+PYDANTIC_VERSIONS = tuple(f"2.{minor}" for minor in range(8, 14))
+
+
+def pydantic_versions_for(python_version: str) -> tuple[str, ...]:
+    """Return the Pydantic versions supported by a Python version."""
+    if python_version == "3.14":
+        return ("2.12", "2.13")
+    if python_version == "3.13":
+        return tuple(f"2.{minor}" for minor in range(8, 14))
+    return PYDANTIC_VERSIONS
+
+
+def make_test_session(python_version: str, pydantic_version: str) -> None:
+    """Register one isolated Python/Pydantic test session."""
+
+    @nox.session(
+        name=f"test-{python_version}-{pydantic_version}",
+        python=python_version,
+        venv_backend="uv",
+    )
+    def test(session: nox.Session) -> None:
+        session.install(
+            ".",
+            f"pydantic=={pydantic_version}",
+            "pytest>=8.4.1",
+            "pytest-cov>=6.2.1",
+        )
+        session.run("pytest", *session.posargs)
+
+
+for _python_version in PYTHON_VERSIONS:
+    for _pydantic_version in pydantic_versions_for(_python_version):
+        make_test_session(_python_version, _pydantic_version)

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,8 +12,6 @@ def pydantic_versions_for(python_version: str) -> tuple[str, ...]:
     """Return the Pydantic versions supported by a Python version."""
     if python_version == "3.14":
         return ("2.12", "2.13")
-    if python_version == "3.13":
-        return tuple(f"2.{minor}" for minor in range(8, 14))
     return PYDANTIC_VERSIONS
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ PYDANTIC_VERSIONS = tuple(f"2.{minor}" for minor in range(8, 14))
 
 def pydantic_versions_for(python_version: str) -> tuple[str, ...]:
     """Return the Pydantic versions supported by a Python version."""
-    if python_version == "3.14":
+    if python_version == "3.14":  # 3.14 support was first added in 2.12
         return ("2.12", "2.13")
     return PYDANTIC_VERSIONS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pydantic>=2.8",
+    "pydantic>=2.8,<3",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dynapydantic"
 version = "0.6.2"
-description = "Dyanmic pydantic models"
+description = "Runtime tracking and polymorphic validation for pydantic models"
 readme = "README.md"
 authors = [
     { name = "Philip Salvaggio", email = "salvaggio.philip@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pydantic>=2.0",
+    "pydantic>=2.8",
 ]
 
 [dependency-groups]
@@ -20,6 +20,7 @@ dev = [
     "mike>=2.1.3",
     "mkdocs-material>=9.6.15",
     "mkdocstrings[python]>=0.29.1",
+    "nox>=2025.10.16",
     "pip>=25.1.1",
     "prek>=0.3.8",
     "pymdown-extensions>=10.16",
@@ -46,6 +47,7 @@ target-version = "py310"
 select = ["ALL"]
 ignore = [
     "COM812", # trailing commas, handled by formatter
+    "CPY001", # not doing copyrights in each file
     "D400", # docstrings end in .
     "ANN002", # Annotations for *args
     "ANN003", # Annotations for *kwargs
@@ -71,6 +73,7 @@ convention = "numpy"
 [tool.pyrefly]
 # We have a few embedded packages in our tests to test out plugins
 search-path = [
+    ".",
     "tests/example/animal-plugins",
     "tests/example/base-package",
     "tests/example/shape-plugins",

--- a/src/dynapydantic/subclass_tracking_model.py
+++ b/src/dynapydantic/subclass_tracking_model.py
@@ -19,6 +19,7 @@ from pydantic_core import PydanticCustomError, core_schema
 from .exceptions import ConfigurationError, Error
 from .tracking_group import TrackingGroup
 from .union_mode import UnionRealization
+from .version_check import pydantic_ge
 
 
 class SubclassTrackingModel(pydantic.BaseModel):
@@ -360,15 +361,25 @@ def _validation_kwargs(
 ) -> dict[str, ty.Any]:
     """Extract keyword arguments for TypeAdapter.validate_python from info."""
     kwargs: dict[str, ty.Any] = {}
+
     if (ctx := getattr(info, "context", None)) is not None:
         kwargs["context"] = ctx
+
     if (config := getattr(info, "config", None)) is not None:
-        for src, dst in (
-            ("extra_fields_behavior", "extra"),
-            ("from_attributes", "from_attributes"),
-            ("validate_by_alias", "by_alias"),
-            ("validate_by_name", "by_name"),
+        # .validate() didn't support extra until 2.12
+        if (
+            pydantic_ge((2, 12, 0))
+            and (val := config.get("extra_fields_behavior")) is not None
         ):
-            if (val := config.get(src)) is not None:
-                kwargs[dst] = val
+            kwargs["extra"] = val
+
+        if pydantic_ge((2, 11, 0)):
+            if (val := config.get("validate_by_alias")) is not None:
+                kwargs["by_alias"] = val
+            if (val := config.get("validate_by_name")) is not None:
+                kwargs["by_name"] = val
+
+        if (val := config.get("from_attributes")) is not None:
+            kwargs["from_attributes"] = val
+
     return kwargs

--- a/src/dynapydantic/version_check.py
+++ b/src/dynapydantic/version_check.py
@@ -1,0 +1,45 @@
+"""Version checking utilities"""
+
+import pydantic
+
+
+def pydantic_le(version: tuple[int, ...]) -> bool:
+    """Test whether the pydantic version is <= ``version``."""
+    return _pydantic_version() <= version
+
+
+def pydantic_lt(version: tuple[int, ...]) -> bool:
+    """Test whether the pydantic version is < ``version``."""
+    return _pydantic_version() < version
+
+
+def pydantic_ge(version: tuple[int, ...]) -> bool:
+    """Test whether the pydantic version is >= ``version``."""
+    return _pydantic_version() >= version
+
+
+def pydantic_gt(version: tuple[int, ...]) -> bool:
+    """Test whether the pydantic version is > ``version``."""
+    return _pydantic_version() > version
+
+
+def pydantic_eq(version: tuple[int, ...]) -> bool:
+    """Test whether the pydantic version is == ``version``."""
+    return _pydantic_version() == version
+
+
+def pydantic_ne(version: tuple[int, ...]) -> bool:
+    """Test whether the pydantic version is != ``version``."""
+    return _pydantic_version() != version
+
+
+_PYDANTIC_VERSION: tuple[int, ...] | None = None
+
+
+def _pydantic_version() -> tuple[int, ...]:
+    global _PYDANTIC_VERSION  # noqa: PLW0603
+
+    if _PYDANTIC_VERSION is None:
+        _PYDANTIC_VERSION = tuple(int(x) for x in pydantic.__version__.split("."))
+
+    return _PYDANTIC_VERSION

--- a/src/dynapydantic/version_check.py
+++ b/src/dynapydantic/version_check.py
@@ -1,4 +1,4 @@
-"""Version checking utilities"""
+"""Version checking utilities."""
 
 import pydantic
 
@@ -21,16 +21,6 @@ def pydantic_ge(version: tuple[int, ...]) -> bool:
 def pydantic_gt(version: tuple[int, ...]) -> bool:
     """Test whether the pydantic version is > ``version``."""
     return _pydantic_version() > version
-
-
-def pydantic_eq(version: tuple[int, ...]) -> bool:
-    """Test whether the pydantic version is == ``version``."""
-    return _pydantic_version() == version
-
-
-def pydantic_ne(version: tuple[int, ...]) -> bool:
-    """Test whether the pydantic version is != ``version``."""
-    return _pydantic_version() != version
 
 
 _PYDANTIC_VERSION: tuple[int, ...] | None = None

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,9 +1,12 @@
 """Tests for how dynapydantic propagates to subclasses"""
 
+import typing as ty
+
 import pydantic
 import pytest
 
 import dynapydantic
+from dynapydantic.version_check import pydantic_lt
 
 
 def test_inheritance_tree_basic() -> None:
@@ -124,7 +127,7 @@ def test_changing_union_from_smart_to_discriminated() -> None:
         f1: dynapydantic.Polymorphic[Base]
         f2: dynapydantic.Polymorphic[MidA]
 
-    assert Container.model_json_schema() == {
+    truth: dict[str, ty.Any] = {
         "$defs": {
             "B": {
                 "properties": {
@@ -201,3 +204,11 @@ def test_changing_union_from_smart_to_discriminated() -> None:
         "title": "Container",
         "type": "object",
     }
+
+    # redundant enum removed in: https://github.com/pydantic/pydantic/pull/11321
+    if pydantic_lt((2, 10, 0)):
+        truth["$defs"]["B"]["properties"]["name"]["enum"] = ["B"]
+        truth["$defs"]["C"]["properties"]["name"]["enum"] = ["C"]
+        truth["$defs"]["MidA"]["properties"]["name"]["enum"] = ["MidA"]
+
+    assert Container.model_json_schema() == truth

--- a/tests/test_subclass_tracking_model.py
+++ b/tests/test_subclass_tracking_model.py
@@ -8,6 +8,8 @@ import pytest
 
 import dynapydantic
 
+from .version_check import skipif_mark_pydantic_version
+
 
 class SimpleKwargBase(dynapydantic.SubclassTrackingModel, discriminator_field="name"):
     """Initialize the TrackingGroup via kwargs"""
@@ -402,6 +404,7 @@ def test_invalid_union_realization(val: int | str) -> None:
                 },
                 "non_poly_shape": None,
             },
+            marks=[skipif_mark_pydantic_version(lt=(2, 12, 0))],
             id="exclude-computed-fields",
         ),
         pytest.param(
@@ -416,7 +419,38 @@ def test_invalid_union_realization(val: int | str) -> None:
                 },
                 "non_poly_shape": {"side": 2.0},
             },
-            id="serialize-as-any",
+            marks=[skipif_mark_pydantic_version(ge=(2, 12, 0))],
+            id="serialize-as-any-lt-2.12",
+        ),
+        pytest.param(
+            {"shape": {"width": 4, "length": 5}, "non_poly_shape": {"side": 2}},
+            {"serialize_as_any": True},
+            {
+                "shape": {
+                    "width": 4.0,
+                    "length": 5.0,
+                    "area": 20.0,
+                    "name": "Rectangle",
+                },
+                "non_poly_shape": {"side": 2.0},
+            },
+            marks=[skipif_mark_pydantic_version(lt=(2, 12, 0), ge=(2, 13, 0))],
+            id="serialize-as-any-2.12",
+        ),
+        pytest.param(
+            {"shape": {"width": 4, "length": 5}, "non_poly_shape": {"side": 2}},
+            {"serialize_as_any": True},
+            {
+                "shape": {
+                    "width": "4.0",
+                    "length": 5.0,
+                    "area": 20.0,
+                    "name": "Rectangle",
+                },
+                "non_poly_shape": {"side": 2.0},
+            },
+            marks=[skipif_mark_pydantic_version(lt=(2, 13, 0))],
+            id="serialize-as-any-ge-2.13",
         ),
         pytest.param(
             {"shape": {"width": 4, "length": 5}, "non_poly_shape": {"side": 2}},
@@ -430,6 +464,7 @@ def test_invalid_union_realization(val: int | str) -> None:
                 },
                 "non_poly_shape": {"side": 2.0},
             },
+            marks=[skipif_mark_pydantic_version(lt=(2, 13, 0))],
             id="polymorphic-serialziation",
         ),
     ],

--- a/tests/test_subclass_tracking_model.py
+++ b/tests/test_subclass_tracking_model.py
@@ -2,6 +2,7 @@
 
 import datetime
 import typing as ty
+from unittest import mock
 
 import pydantic
 import pytest
@@ -117,6 +118,35 @@ def test_invalid_union_modes() -> None:
 
         class Base(dynapydantic.SubclassTrackingModel, union_mode="foo"):
             pass
+
+
+def test_json_reencode_failure() -> None:
+    """A JSON re-encoding failure should become a validation error."""
+
+    class Base(
+        dynapydantic.SubclassTrackingModel,
+        discriminator_field="name",
+        union_realization="validation",
+    ):
+        pass
+
+    class A(Base):
+        name: ty.Literal["A"] = "A"
+        a: int
+
+    class Model(pydantic.BaseModel):
+        value: dynapydantic.Polymorphic[Base]
+
+    with (
+        mock.patch(
+            "dynapydantic.subclass_tracking_model.json.dumps",
+            side_effect=TypeError("cannot encode value"),
+        ) as dumps,
+        pytest.raises(pydantic.ValidationError, match="JSON re-encoding failed"),
+    ):
+        Model.model_validate_json('{"value": {"name": "A", "a": 1}}')
+
+    dumps.assert_called_once_with({"name": "A", "a": 1})
 
 
 def test_three_level_subclass_hierarchy() -> None:

--- a/tests/test_subclass_tracking_model.py
+++ b/tests/test_subclass_tracking_model.py
@@ -9,7 +9,7 @@ import pytest
 
 import dynapydantic
 
-from .version_check import skipif_mark_pydantic_version
+from .version_marks import skipif_mark_pydantic_version
 
 
 class SimpleKwargBase(dynapydantic.SubclassTrackingModel, discriminator_field="name"):

--- a/tests/test_validation_time_adapter.py
+++ b/tests/test_validation_time_adapter.py
@@ -7,6 +7,7 @@ import pydantic
 import pytest
 
 import dynapydantic
+from dynapydantic.version_check import pydantic_le, pydantic_lt
 
 
 def test_validation_time_union_no_members() -> None:
@@ -131,6 +132,12 @@ def test_validation_time_adapter_forwards_context() -> None:
             {"extra": "forbid"},
             {"value": {"value": 2, "unexpected": True}},
             "unexpected",
+            marks=[
+                pytest.mark.xfail(
+                    pydantic_le((2, 12, 0)),
+                    reason="TypeAdapter's didn't gain support for extra until 2.12",
+                )
+            ],
             id="extra",
         ),
     ],
@@ -183,6 +190,10 @@ def test_validation_time_adapter_forwards_from_attributes() -> None:
     assert Model.model_validate({"value": Input()}).value == Child(value=7)
 
 
+@pytest.mark.xfail(
+    pydantic_lt((2, 11, 0)),
+    reason="TypeAdapter's didn't support alias config before 2.11.0",
+)
 def test_validation_time_adapter_forwards_alias_configuration() -> None:
     """Alias and field-name settings reach the realized subclass."""
 

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -1,0 +1,28 @@
+"""Unit tests for pydantic version checking utilities."""
+
+import re
+from unittest import mock
+
+import pydantic
+
+from dynapydantic import version_check
+
+
+def test_pydantic_version_has_major_minor_patch() -> None:
+    """The installed pydantic version is a major.minor.patch version."""
+    assert hasattr(pydantic, "__version__")
+    assert re.fullmatch(r"\d+\.\d+\.\d+", pydantic.__version__)
+
+
+def test_version_comparisons_use_pydantic_version() -> None:
+    """Comparison helpers parse and compare the pydantic version."""
+    with (
+        mock.patch.object(pydantic, "__version__", "2.3.4"),
+        mock.patch.object(version_check, "_PYDANTIC_VERSION", None),
+    ):
+        assert version_check.pydantic_le((2, 3, 4))
+        assert version_check.pydantic_lt((2, 3, 5))
+        assert version_check.pydantic_ge((2, 3, 4))
+        assert version_check.pydantic_gt((2, 3, 3))
+        assert version_check.pydantic_eq((2, 3, 4))
+        assert version_check.pydantic_ne((2, 3, 5))

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -24,5 +24,3 @@ def test_version_comparisons_use_pydantic_version() -> None:
         assert version_check.pydantic_lt((2, 3, 5))
         assert version_check.pydantic_ge((2, 3, 4))
         assert version_check.pydantic_gt((2, 3, 3))
-        assert version_check.pydantic_eq((2, 3, 4))
-        assert version_check.pydantic_ne((2, 3, 5))

--- a/tests/version_check.py
+++ b/tests/version_check.py
@@ -1,0 +1,38 @@
+"""Version checking utilities."""
+
+import pytest
+
+from dynapydantic.version_check import (
+    pydantic_ge,
+    pydantic_gt,
+    pydantic_le,
+    pydantic_lt,
+)
+
+
+def skipif_mark_pydantic_version(
+    *,
+    le: tuple[int, ...] | None = None,
+    lt: tuple[int, ...] | None = None,
+    ge: tuple[int, ...] | None = None,
+    gt: tuple[int, ...] | None = None,
+) -> pytest.MarkDecorator:
+    """Return a pydantic.mark.skipif based on the pydantic version.
+
+    Skips the test if ANY passed condition is true.
+    """
+    msg: str | None = None
+    if le is not None and pydantic_le(le):
+        msg = "Pydantic version was <= {'.'.join(str(x) for x in le)}"
+    elif lt is not None and pydantic_lt(lt):
+        msg = "Pydantic version was < {'.'.join(str(x) for x in lt)}"
+    elif ge is not None and pydantic_ge(ge):
+        msg = "Pydantic version was >= {'.'.join(str(x) for x in ge)}"
+    elif gt is not None and pydantic_gt(gt):
+        msg = "Pydantic version was > {'.'.join(str(x) for x in gt)}"
+
+    return (
+        pytest.mark.skip(msg)
+        if msg is not None
+        else pytest.mark.skipif(False, reason="N/A")
+    )

--- a/tests/version_marks.py
+++ b/tests/version_marks.py
@@ -23,13 +23,13 @@ def skipif_mark_pydantic_version(
     """
     msg: str | None = None
     if le is not None and pydantic_le(le):
-        msg = "Pydantic version was <= {'.'.join(str(x) for x in le)}"
+        msg = f"Pydantic version was <= {'.'.join(str(x) for x in le)}"
     elif lt is not None and pydantic_lt(lt):
-        msg = "Pydantic version was < {'.'.join(str(x) for x in lt)}"
+        msg = f"Pydantic version was < {'.'.join(str(x) for x in lt)}"
     elif ge is not None and pydantic_ge(ge):
-        msg = "Pydantic version was >= {'.'.join(str(x) for x in ge)}"
+        msg = f"Pydantic version was >= {'.'.join(str(x) for x in ge)}"
     elif gt is not None and pydantic_gt(gt):
-        msg = "Pydantic version was > {'.'.join(str(x) for x in gt)}"
+        msg = f"Pydantic version was > {'.'.join(str(x) for x in gt)}"
 
     return (
         pytest.mark.skip(msg)

--- a/tests/version_marks.py
+++ b/tests/version_marks.py
@@ -1,4 +1,4 @@
-"""Version checking utilities."""
+"""Pytest marks related to third-party versions."""
 
 import pytest
 
@@ -17,7 +17,7 @@ def skipif_mark_pydantic_version(
     ge: tuple[int, ...] | None = None,
     gt: tuple[int, ...] | None = None,
 ) -> pytest.MarkDecorator:
-    """Return a pydantic.mark.skipif based on the pydantic version.
+    """Return a pytest.mark.skipif based on the pydantic version.
 
     Skips the test if ANY passed condition is true.
     """

--- a/uv.lock
+++ b/uv.lock
@@ -391,7 +391,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.8" }]
+requires-dist = [{ name = "pydantic", specifier = ">=2.8,<3" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -418,7 +418,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -18,6 +22,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "argcomplete"
+version = "3.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/6f/5a73f04007ca950701765949209f068da628bd11f9c2da287278ce91e0ee/argcomplete-3.7.2.tar.gz", hash = "sha256:aad8b69a0b9969edb62db0d1752354c0d50717b10e0cbb00e2a958381b9fc6b9", size = 74473, upload-time = "2026-08-06T04:53:21.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/bd/551ee6af426af84ca33e02622be722925c196608e9127d731ef17c47f06e/argcomplete-3.7.2-py3-none-any.whl", hash = "sha256:6029205678bdd9c1c728a155f5f9ecf5812393f969eef58807641a2bc2aa5b19", size = 43294, upload-time = "2026-08-06T04:53:20.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -157,6 +179,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/55/ba79756cb90c8d69d599d57785398ac87bba7b19c80e87f4e8a562197c93/colorlog-6.12.0.tar.gz", hash = "sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f", size = 18151, upload-time = "2026-07-23T13:40:40.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/19/0b6647bf5e331521e55d2b63bfbdc210bd9cd605189273f03614a05f702d/colorlog-6.12.0-py3-none-any.whl", hash = "sha256:30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e", size = 12239, upload-time = "2026-07-23T13:40:39.562Z" },
 ]
 
 [[package]]
@@ -307,6 +341,28 @@ wheels = [
 ]
 
 [[package]]
+name = "dependency-groups"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/55/f054de99871e7beb81935dea8a10b90cd5ce42122b1c3081d5282fdb3621/dependency_groups-1.3.1.tar.gz", hash = "sha256:78078301090517fd938c19f64a53ce98c32834dfe0dee6b88004a569a6adfefd", size = 10093, upload-time = "2025-05-02T00:34:29.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/c7/d1ec24fb280caa5a79b6b950db565dab30210a66259d17d5bb2b3a9f878d/dependency_groups-1.3.1-py3-none-any.whl", hash = "sha256:51aeaa0dfad72430fcfb7bcdbefbd75f3792e5919563077f30bc0d73f4493030", size = 8664, upload-time = "2025-05-02T00:34:27.085Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "dynapydantic"
 version = "0.6.2"
 source = { editable = "." }
@@ -323,6 +379,7 @@ dev = [
     { name = "mike" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "nox" },
     { name = "pip" },
     { name = "prek" },
     { name = "pymdown-extensions" },
@@ -334,7 +391,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.0" }]
+requires-dist = [{ name = "pydantic", specifier = ">=2.8" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -345,6 +402,7 @@ dev = [
     { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs-material", specifier = ">=9.6.15" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
+    { name = "nox", specifier = ">=2025.10.16" },
     { name = "pip", specifier = ">=25.1.1" },
     { name = "prek", specifier = ">=0.3.8" },
     { name = "pymdown-extensions", specifier = ">=10.16" },
@@ -374,6 +432,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/64/a02e6765de08964ed371eca577870593245afc9dfac16d037de7c10d18e6/filelock-3.32.3.tar.gz", hash = "sha256:0ffa185a3540854c95caa7fa76b76cb219d907415e2c5dc9af25fd970563487f", size = 218135, upload-time = "2026-08-13T16:00:05.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl", hash = "sha256:7f0ca4bcc0e181c60dbbd8aa9ab5b120ebb99e4e064e83636340056f833a1f09", size = 98901, upload-time = "2026-08-13T16:00:03.974Z" },
 ]
 
 [[package]]
@@ -419,6 +486,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
+name = "humanize"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ea/13a1ef3c12d12662905801495283530251918b70d62d368f1d2e0272c70d/humanize-4.16.0.tar.gz", hash = "sha256:7dc2244a2f84a4bfb1d36c37bac80cd78e35cdc5c119206d87b018e1445f3a3f", size = 89515, upload-time = "2026-06-30T16:17:29.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/aa/0b7365d30fed43e7a3449aba1fe20a0a7174d9cf13e282af4e69ac825441/humanize-4.16.0-py3-none-any.whl", hash = "sha256:353eb2f34c09d098b2880eee8bef21832eae6d174f48c5762fff7e5fcb74d01d", size = 137209, upload-time = "2026-06-30T16:17:28.36Z" },
 ]
 
 [[package]]
@@ -710,6 +786,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
+]
+
+[[package]]
+name = "nox"
+version = "2026.8.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "attrs" },
+    { name = "colorlog" },
+    { name = "dependency-groups" },
+    { name = "humanize" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/78/74026b59fd3becd3a549498e8f7809e768c9a1db808f6f016f88b638eda6/nox-2026.8.10.tar.gz", hash = "sha256:13f45e46552eade9f4b60474133e31e1e0bb341234a3cc0c9d6fff17570ce8bb", size = 4075448, upload-time = "2026-08-10T21:53:18.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/6a/020c992d7121377b27676af368d5d5287121a9bb12216264d979961e90d8/nox-2026.8.10-py3-none-any.whl", hash = "sha256:943f1ebcace1efb35d91ad2034007df1942d2a1bed75fb33e1bf0ed5a0df1cdb", size = 94662, upload-time = "2026-08-10T21:53:16.477Z" },
 ]
 
 [[package]]
@@ -1029,6 +1126,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/b7/ac44da2cf0e53ada0e419033c2d058219c95dc1403126f163304c9e814b1/python_discovery-1.5.2.tar.gz", hash = "sha256:45fd4f20a4e3f9b7bf2e0817870bc8e3b320a19658da177af800768c82dbf354", size = 82350, upload-time = "2026-08-12T14:05:26.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/45/689603d04b3bb8d7faa00f25c24acef993aab7813b3dbbfc472a459ab0b5/python_discovery-1.5.2-py3-none-any.whl", hash = "sha256:3e338c2d0f15dfaeea57493f4c2c6caebe0e998ea815c30ae8bf8ee21f1112d3", size = 38350, upload-time = "2026-08-12T14:05:25.113Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1281,6 +1390,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/dc/a6eb1ddfa7f1e390fa599b078453c97edb3f6f846b34fb4eac3e8ea16401/virtualenv-21.7.4.tar.gz", hash = "sha256:c9d960c95fa458171e58222a5ccab7465298e4b6559977865e627c4719f1e825", size = 5345511, upload-time = "2026-08-10T22:54:33.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4c/eb2f52aeeaf30dbd073d315a251a63ae2b8263171ec4428c135140cb0802/virtualenv-21.7.4-py3-none-any.whl", hash = "sha256:376ec93cd6aab3044fa395d7db226db38043b7b5748948044b2a87168525e843", size = 5324444, upload-time = "2026-08-10T22:54:31.515Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Prior to this PR, `dynapydantic` was really only tested against the latest version of `pydantic` on each version of Python. This PR adds a formal testing matrix over versions of Python and Pydantic, establishing a compatibility matrix. This is tracked via `noxfile.py` and documented in the README.md.

It was found that prior to `pydantic` 2.8, smart unions were not evaluating well enough to support their inclusion in this library. So, the minimum pin has been raised to >= 2.8 and the maximum version has been tightened to <3 to guard against future breaking changes.

This pin will continue to be updated in the future to reflect the testing matrix.